### PR TITLE
Simplify using, sum-type, and any

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A module for `TOML v1.0.0` support. It provides functionality to read/write TOML
 - All run-time data types are supported as their native type including reference types (`pointer`, `array`, `any`), with the exception of untagged `unions`.
 - Generic data is supported through the [Toml.Value](src/data.jai) struct.
 - Dates/times are supported types provided in [src/datetime.jai](src/datetime.jai) (until Jai has native types).
-- Safe sum-types with `@UnionTag` notes to indicate the tag member corresponding to a union.
+- Safe sum-types with `@SumType` notes to indicate the tag member corresponding to a union.
 - There is currently no way to provide an alternative (de)serialization procedures for a user-defined type (e.g. Jai's Tagged_Union would serialize as an array of u8 numbers and the contents of the Type_Info)
 
 Latest confirmed compatible Jai Version: beta 0.2.008, built on 14 January 2025.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A module for `TOML v1.0.0` support. It provides functionality to read/write TOML
 - Full TOML v1.0.0 support.
 - All run-time data types are supported as their native type including reference types (`pointer`, `array`, `any`), with the exception of untagged `unions`.
 - Generic data is supported through the [Toml.Value](src/data.jai) struct.
-- Dates/times are supported types provided in [src/datetime.jai](src/datetime.jai) (until Jai has native types).
+- Dates/times are supported types provided in [src/datetime.jai](src/datetime.jai) (until Jai has native types, Apollo_time.Calendar_Time is not usable here).
 - Safe sum-types with `@SumType` notes to indicate the tag member corresponding to a union.
 - There is currently no way to provide an alternative (de)serialization procedures for a user-defined type (e.g. Jai's Tagged_Union would serialize as an array of u8 numbers and the contents of the Type_Info)
 

--- a/examples/first.jai
+++ b/examples/first.jai
@@ -56,26 +56,26 @@ DONE
     // A tagged union / sum-type requires the tag in the toml to be correctly matching the set union
     // To make the TAG optional and prevent incorrect tags you can declare the union's tag member with a note like @UnionTag:mytag
     // NOTE: Make sure the union initializes to the first variant by disabling initialization of the other variants with ---.
-    Guy :: struct {
-        using joost: union { // @compiler It would be nice if we could add a tag to anonymous using unions
-            banana: void;
-            apple: struct { a: u8; b: string;} = ---;
-            orange: string = ---;
-        }; @UnionTag:mytag
+    Guy :: struct @TaggedUnion {
         mytag: enum {
             BANANA;
             APPLE;
             ORANGE;
         };
+        using joost: union { // @compiler It would be nice if we could add a tag to anonymous using unions
+            banana: void;
+            apple: struct { a: u8; b: string;} = ---;
+            orange: string = ---;
+        }; @UnionTag:mytag // TODO remove
     }
     ok=, apple := Toml.deserialize("apple = {a = 32, b = 'Y'}", Guy); assert(ok);
     print("struct_apple: %\n", apple);
     print("struct_apple: %: %\n", apple.mytag, apple.apple);
     ok_apple, toml_apple := Toml.serialize(apple); assert(ok_apple);
-    log("struct_apple serialized:\n%", toml_apple);
+    assert("APPLE={a=32, b=\"Y\"}\n" == toml_apple, "%", toml_apple);
 
     // If the TOML data does not contain a field that is present in the struct, the field will be initialized to its default value.
-    // Jai's initialization of unions is wack. So instead unions are initialized always initialized to the first variant.
+    // Jai's initialization of unions is wack. So it is highly recommended to use --- to disable initialization of all variants that do not correspond to the default tag.
     ok=, void_banana := Toml.deserialize("", Guy); assert(ok);
     print("void_banana: %\n", void_banana);
     print("void_banana: %: %\n", void_banana.mytag, void_banana.banana);
@@ -146,7 +146,7 @@ using_members :: () {
     assert(named_using2.hi.q == 0, "%", named_using2.hi.q);
     // When serializing a pointer member it will also omit the member name.
     ok=, named_using_str := Toml.serialize(named_using1); assert(ok);
-    assert(named_using_str == "q=99\n");
+    assert(named_using_str == "hi.q=99\n", "%", named_using_str);
 
     // A pointer member that is declared `using` is different.
     // In this case it is ONLY possible to set by explicitly naming the using member.

--- a/examples/first.jai
+++ b/examples/first.jai
@@ -5,7 +5,7 @@ main :: () {
     heap := create_heap(context.allocator);
     defer destroy_heap(heap);
     ok, toml_value := Toml.deserialize(contents, Toml.Value,, allocator=heap); assert(ok);
-    ok_toml, toml := Toml.serialize(toml_value); assert(ok_toml);
+    ok_toml, toml := Toml.serialize(toml_value,, allocator=heap); assert(ok_toml);
     print("%\n", toml);
 
     // We can also deserialize the TOML data into a struct. The struct must have the same fields as the TOML data.
@@ -48,44 +48,23 @@ DONE
     ok=, as_value := Toml.serialize(my_struct); assert(ok);
     print("%\n", as_value);
 
+    // If the TOML data does not contain a field that is present in the struct, the field will be initialized to its default value.
+    ok=, default_struct := Toml.deserialize("", Q); assert(ok);
+    assert(default_struct.q == 0, "%", default_struct.q);
+
     // When struct or pointer members of a struct are declared with `using` the member name are required in the TOML data.
-    // If the member is anonymous the member name IS omitted.
+    // If the member is anonymous the member name is an empty string "".
     using_members();
 
-    // All run-time types are supported.
-    // A tagged union / sum-type requires the tag in the toml to be correctly matching the set union
-    // To make the TAG optional and prevent incorrect tags you can declare the union's tag member with a note like @UnionTag:mytag
-    // NOTE: Make sure the union initializes to the first variant by disabling initialization of the other variants with ---.
-    Guy :: struct @TaggedUnion {
-        mytag: enum {
-            BANANA;
-            APPLE;
-            ORANGE;
-        };
-        using joost: union { // @compiler It would be nice if we could add a tag to anonymous using unions
-            banana: void;
-            apple: struct { a: u8; b: string;} = ---;
-            orange: string = ---;
-        }; @UnionTag:mytag // TODO remove
-    }
-    ok=, apple := Toml.deserialize("APPLE = {a = 32, b = 'Y'}", Guy); assert(ok);
-    print("struct_apple: %\n", apple);
-    print("struct_apple: %: %\n", apple.mytag, apple.apple);
-    ok_apple, toml_apple := Toml.serialize(apple); assert(ok_apple);
-    assert("APPLE={a=32, b=\"Y\"}\n" == toml_apple, "%", toml_apple);
-
-    // If the TOML data does not contain a field that is present in the struct, the field will be initialized to its default value.
-    // Jai's initialization of unions is wack. So it is highly recommended to use --- to disable initialization of all variants that do not correspond to the default tag.
-    ok=, void_banana := Toml.deserialize("", Guy); assert(ok);
-    print("void_banana: %\n", void_banana);
-    print("void_banana: %: %\n", void_banana.mytag, void_banana.banana);
+    // All run-time types are supported, excepts for serializing untagged unions. Unions are supported by tagging them tagging.
+    unions_and_place();
 
     // For convenience Toml.Value comes with an equality operator and copy procedure.
     ok=, left := Toml.deserialize("a.b = {c.d = 1}", Toml.Value); assert(ok);
     ok=, right := Toml.deserialize("a.b.c.d = 1", Toml.Value); assert(ok);
-    assert(left == right);
+    assert(left == copy(right));
 
-    // Jai does not have commonly used types for dates and times. This module provides date/time types until the languages does.
+    // Jai Apollo_time.Calendar_Time is not usable for TOML dates/times. This module provides date/time types until the languages does.
     MyTime :: struct   { t: DateTimeOffset; }
     ok=, mytime := Toml.deserialize("t = 1979-05-27 07:32:00Z", MyTime); assert(ok);
     print("time: %\n", mytime);
@@ -108,21 +87,6 @@ DONE
     MyFloat :: struct { f: float; }
     ok=, myfloat := Toml.deserialize("f = 3", MyFloat); assert(ok);
     assert (myfloat.f == 3.0);
-
-    {
-        // If a structure has overlapping members / members with different names through the #place directive
-        // they are all serialized. This is inconsistent with Basic.print which skips members that overlap previous members.
-        // Note that this may be unsafe if #place is used for a union use-case like a string overlapping some floats. In this case,
-        // if the floats are "active" the string is still serialized assuming the data pointer is valid. -- Perhaps we should simply not allow #place.
-        // When deserializing the last overlapping member in the struct definition that is also in the toml wins.
-        #import "Math";
-        has_hash_place:= Plane3.{3., 81., .18, .65};
-        print("has_hash_place: %\n", has_hash_place);
-        ok=, hash_toml:= Toml.serialize(has_hash_place); assert(ok);
-        print("hash_toml: %\n", hash_toml);
-        ok=, new_plane:= Toml.deserialize("[vector4] \n xy = {x=2., y=21.6} \n zw = {x=.12, y=.25}", Plane3); assert(ok);
-        assert("{2, 21.6, 0.12, 0.25}" == tprint("%", new_plane));
-    }
 
     // Pointers, ANY, VIEW and RESIZABLE arrays are supported at any depth in the struct definition.
     // These types that are referencing memory elsewhere will have new memory allocated for them with the context allocator.
@@ -176,6 +140,46 @@ using_members :: () {
 "".q=96
 "".t="hello"
 DONE, "%", anonymous_using_str);
+}
+
+unions_and_place :: () {
+    // A struct with a @SumType is required to have the first member be the tag and the second be the union with the same number of members as the tag.
+    // Jai's initialization of unions is wack. So it is highly recommended to use --- to disable initialization of all variants that do not correspond to the default tag.
+    Guy :: struct @SumType {
+        mytag: enum {
+            BANANA;
+            APPLE;
+            ORANGE;
+        }= .ORANGE;
+        union {
+            banana: void = ---;
+            apple: struct { a: u8; b: string;} = ---;
+            orange: string="default";
+        };
+    }
+    ok, apple := Toml.deserialize("APPLE = {a = 32, b = 'Y'}", Guy); assert(ok);
+    print("struct_apple: %\n", apple);
+    print("struct_apple: %: %\n", apple.mytag, apple.apple);
+    ok_apple, toml_apple := Toml.serialize(apple); assert(ok_apple);
+    assert("APPLE={a=32, b=\"Y\"}\n" == toml_apple, "%", toml_apple);
+
+    // If the TOML data does not contain a field that is present in the struct, the field will be initialized to its default value.
+    ok=, void_orange := Toml.deserialize("", Guy); assert(ok);
+    assert(void_orange.mytag == .ORANGE, "%", void_orange.mytag);
+    assert(void_orange.orange == "default", "%", void_orange.orange);
+
+    // If a structure has overlapping members / members with different names through the #place directive
+    // they are all serialized. This is inconsistent with Basic.print which skips members that overlap previous members.
+    // Note that this may be unsafe if #place is used for a union use-case like a string overlapping some floats. In this case,
+    // if the floats are "active" the string is still serialized assuming the data pointer is valid. -- Perhaps we should simply not allow #place.
+    // When deserializing the last overlapping member in the struct definition that is also in the toml wins.
+    #import "Math";
+    has_hash_place:= Plane3.{3., 81., .18, .65};
+    print("has_hash_place: %\n", has_hash_place);
+    ok=, hash_toml:= Toml.serialize(has_hash_place); assert(ok);
+    print("hash_toml: %\n", hash_toml);
+    ok=, new_plane:= Toml.deserialize("[vector4] \n xy = {x=2., y=21.6} \n zw = {x=.12, y=.25}", Plane3); assert(ok);
+    assert("{2, 21.6, 0.12, 0.25}" == tprint("%", new_plane));
 }
 
 error_handling :: () {

--- a/examples/first.jai
+++ b/examples/first.jai
@@ -152,7 +152,7 @@ unions_and_place :: () {
             ORANGE;
         }= .ORANGE;
         union {
-            banana: void = ---;
+            banana: *s64 = ---;
             apple: struct { a: u8; b: string;} = ---;
             orange: string="default";
         };
@@ -167,6 +167,10 @@ unions_and_place :: () {
     ok=, void_orange := Toml.deserialize("", Guy); assert(ok);
     assert(void_orange.mytag == .ORANGE, "%", void_orange.mytag);
     assert(void_orange.orange == "default", "%", void_orange.orange);
+
+    // Serializing SumTypes to null pointers/anys is not supported.
+    null_banana := Guy.{mytag=.BANANA, banana=null};
+    ok = Toml.serialize(null_banana); assert(!ok);
 
     // If a structure has overlapping members / members with different names through the #place directive
     // they are all serialized. This is inconsistent with Basic.print which skips members that overlap previous members.

--- a/examples/first.jai
+++ b/examples/first.jai
@@ -68,7 +68,7 @@ DONE
             orange: string = ---;
         }; @UnionTag:mytag // TODO remove
     }
-    ok=, apple := Toml.deserialize("apple = {a = 32, b = 'Y'}", Guy); assert(ok);
+    ok=, apple := Toml.deserialize("APPLE = {a = 32, b = 'Y'}", Guy); assert(ok);
     print("struct_apple: %\n", apple);
     print("struct_apple: %: %\n", apple.mytag, apple.apple);
     ok_apple, toml_apple := Toml.serialize(apple); assert(ok_apple);
@@ -138,15 +138,15 @@ using_members :: () {
     Named_Using :: struct {
         using hi: struct { q: u8; };
     }
-    ok, named_using1 := Toml.deserialize("q = 99", Named_Using); assert(ok);
-    assert(named_using1.q == 99, "%", named_using1.q);
+    ok, named_using1 := Toml.deserialize("q = 99", Named_Using); assert(ok); // TODO UPDATE EXAMPLES COMMENTS
+    assert(named_using1.q == 0, "%", named_using1.q);
     // When a struct members is declared with `using` the member name cannot be used in the TOML to set the data
     // This is to prevent having multiple ways to define the same data. It also reduced the amount of recursion we have to do when deserializing.
     ok=, named_using2 := Toml.deserialize("hi = { q=98 }", Named_Using); assert(ok);
-    assert(named_using2.hi.q == 0, "%", named_using2.hi.q);
+    assert(named_using2.hi.q == 98, "%", named_using2.hi.q);
     // When serializing a pointer member it will also omit the member name.
-    ok=, named_using_str := Toml.serialize(named_using1); assert(ok);
-    assert(named_using_str == "hi.q=99\n", "%", named_using_str);
+    ok=, named_using_str := Toml.serialize(named_using2); assert(ok);
+    assert(named_using_str == "hi.q=98\n", "%", named_using_str);
 
     // A pointer member that is declared `using` is different.
     // In this case it is ONLY possible to set by explicitly naming the using member.

--- a/examples/first.jai
+++ b/examples/first.jai
@@ -44,12 +44,12 @@ DONE
     }
 
     ok=, my_struct := Toml.deserialize(THE_STRING, MyStruct); assert(ok);
-    print("MyStruct: %\n", my_struct);
+    assert("{false, 23.299999, {32, \"Y\", Y}, [{2}, {-3}, {4}], \"Mai\"}" == tprint("%", my_struct), "%", my_struct);
     ok=, as_value := Toml.serialize(my_struct); assert(ok);
-    log("serialize:\n%", as_value);
+    print("%\n", as_value);
 
-    // When struct members of a struct are declared with `using` the member name is omitted in the TOML data.
-    // When pointer members of a struct are declared with `using` the member name is NOT omitted in the TOML data.
+    // When struct or pointer members of a struct are declared with `using` the member name are required in the TOML data.
+    // If the member is anonymous the member name IS omitted.
     using_members();
 
     // All run-time types are supported.
@@ -134,22 +134,21 @@ DONE
 }
 
 using_members :: () {
-    // When a member is declared `using` the member name is omitted and the members are set directly as if part of the struct.
+    // When a named member is declared `using` the member name is still required.
     Named_Using :: struct {
         using hi: struct { q: u8; };
     }
-    ok, named_using1 := Toml.deserialize("q = 99", Named_Using); assert(ok); // TODO UPDATE EXAMPLES COMMENTS
-    assert(named_using1.q == 0, "%", named_using1.q);
-    // When a struct members is declared with `using` the member name cannot be used in the TOML to set the data
+    ok, named_using1:= Toml.deserialize("hi = { q=98 }", Named_Using); assert(ok);
+    assert(named_using1.hi.q == 98, "%", named_using1.hi.q);
+    // When a struct members is declared with `using` the member name cannot be omitted in the TOML to set the data
     // This is to prevent having multiple ways to define the same data. It also reduced the amount of recursion we have to do when deserializing.
-    ok=, named_using2 := Toml.deserialize("hi = { q=98 }", Named_Using); assert(ok);
-    assert(named_using2.hi.q == 98, "%", named_using2.hi.q);
-    // When serializing a pointer member it will also omit the member name.
-    ok=, named_using_str := Toml.serialize(named_using2); assert(ok);
+    ok=, named_using2 := Toml.deserialize("q = 99", Named_Using); assert(ok);
+    assert(named_using2.q == 0, "%", named_using2.q); // 0 since is the default value when it is not set
+    // When serializing a using member it will also write the member name.
+    ok=, named_using_str := Toml.serialize(named_using1); assert(ok);
     assert(named_using_str == "hi.q=98\n", "%", named_using_str);
 
-    // A pointer member that is declared `using` is different.
-    // In this case it is ONLY possible to set by explicitly naming the using member.
+    // A pointer member that is declared `using` is the same.
     Q :: struct {
         q: s16;
     }
@@ -161,6 +160,22 @@ using_members :: () {
     // When serializing a pointer member it will not omit the member name, consistent with deserialization.
     ok=, pointer_using_str := Toml.serialize(pointer_using); assert(ok);
     assert(pointer_using_str == "hi.q=97\n");
+
+    // An anonymous member that is declared `using` still require the empty key "" in the TOML data.
+    // The members however are clustered together into a single table.
+    Anonymous_Using :: struct {
+        struct { q: u8; };
+        struct { t: string; };
+    }
+    ok=, anonymous_using:= Toml.deserialize("'' = { q = 96, t = 'hello' }", Anonymous_Using); assert(ok);
+    assert(anonymous_using.q == 96, "%", anonymous_using.q);
+    assert(anonymous_using.t == "hello", "%", anonymous_using.t);
+    // When serializing an anonymous using member it will not omit the member name, consistent with deserialization.
+    ok=, anonymous_using_str := Toml.serialize(anonymous_using); assert(ok);
+    assert(anonymous_using_str == #string DONE
+"".q=96
+"".t="hello"
+DONE, "%", anonymous_using_str);
 }
 
 error_handling :: () {
@@ -262,7 +277,7 @@ reference_types :: () {
     MyUnionPtr :: struct {
         p_union: *MyUnionStruct;
     }
-    ok=, un_ptr := Toml.deserialize("tag = 'FIRST' \n p_union.first.number = 3", MyUnionPtr); assert(ok);
+    ok=, un_ptr := Toml.deserialize("tag = 'FIRST' \n p_union.''.first.number = 3", MyUnionPtr); assert(ok);
     print("un_ptr: %: %\n", un_ptr.p_union.tag, un_ptr.p_union.first);
     assert(un_ptr.p_union.first.number == 3);
     assert(un_ptr.p_union.first.getal == 23);

--- a/examples/first.jai
+++ b/examples/first.jai
@@ -308,7 +308,10 @@ reference_types :: () {
     ok=, toml4 = Toml.deserialize("andy = true", Amy); assert(ok);
     assert("{true}" == tprint("%", toml4));
     ok=, toml4 = Toml.deserialize("andy = [1, 7, 3]", Amy); assert(ok);
-    assert("{[1, 7, 3]}" == tprint("%", toml4));
+    assert(toml4.andy.type.type == .ARRAY);
+    array_info :*Type_Info_Array= xx toml4.andy.type;
+    assert(array_info.element_type == type_info(Toml.Value));
+    for cast(*[]Toml.Value, toml4.andy.value_pointer).* { assert(it.type == .INT); }
     ok=, toml4 = Toml.deserialize("andy = [1, 'd', 3]", Amy); assert(ok);
     print("%\n", toml4);
 

--- a/src/data.jai
+++ b/src/data.jai
@@ -10,13 +10,13 @@ Value :: struct {
     }
     type :Type= .TABLE;
     union {
-        bool_value     : bool = ---;
-        int_value      : s64 = ---;
-        float_value    : float64 = ---;
-        string_value   : string = ---;
-        datetime       : Chrono = ---;
-        array          : [..]Value = ---;
-        table          : [..]KeyValue;
+        bool_value   : bool = ---;
+        int_value    : s64 = ---;
+        float_value  : float64 = ---;
+        string_value : string = ---;
+        datetime     : Chrono = ---;
+        array        : [..]Value = ---;
+        table        : [..]KeyValue;
     };
 }
 KeyValue :: struct {

--- a/src/data.jai
+++ b/src/data.jai
@@ -1,4 +1,4 @@
-Value :: struct {
+Value :: struct @SumType {
     Type :: enum u8 {
         BOOL;
         INT;

--- a/src/datetime.jai
+++ b/src/datetime.jai
@@ -2,7 +2,7 @@
 // https://datatracker.ietf.org/doc/html/rfc3339
 // These types are to be removed when there is a commonly used datetime module in Jai
 
-Chrono :: struct {
+Chrono :: struct @SumType {
     Type :: enum u8 {
         LOCAL_TIME;
         LOCAL_DATE;

--- a/src/deserialize.jai
+++ b/src/deserialize.jai
@@ -89,32 +89,14 @@ value_to_type :: (toml: Value, slot: *void, info: *Type_Info, parent_name:string
         }
     case .ANY;
         any_value :*Any_Struct= xx slot;
-
-        homogeneous_array_info :: (array: []Value) -> is_same_type:bool, *Type_Info {
-            if array.count == 0 { return false, null; }
-            first_type := array[0].type;
-            if first_type == .ARRAY || first_type == .TABLE { return false, null; } // Not going down multiple levels
-            for array { if it.type != first_type { return false, null; }}
-            if first_type == {
-            case .BOOL;     return true, type_info([]type_of(Value.bool_value));
-            case .INT;      return true, type_info([]type_of(Value.int_value));
-            case .FLOAT;    return true, type_info([]type_of(Value.float_value));
-            case .STRING;   return true, type_info([]type_of(Value.string_value));
-            case .DATETIME; return true, type_info([]type_of(Value.datetime));
-            }
-            return false, null;
-        }
-
         if #complete toml.type == {
         case .BOOL;     any_value.type = type_info(type_of(Value.bool_value));
         case .INT;      any_value.type = type_info(type_of(Value.int_value));
         case .FLOAT;    any_value.type = type_info(type_of(Value.float_value));
         case .STRING;   any_value.type = type_info(type_of(Value.string_value));
         case .DATETIME; any_value.type = type_info(type_of(Value.datetime));
-        case .ARRAY;
-            is_same, array_type := homogeneous_array_info(toml.array);
-            any_value.type = ifx is_same then array_type else type_info(type_of(Value.array));
-        case .TABLE;  any_value.type = type_info(type_of(Value.table));
+        case .ARRAY;    any_value.type = type_info(type_of(Value.array));
+        case .TABLE;    any_value.type = type_info(type_of(Value.table));
         }
         any_value.value_pointer = alloc(any_value.type.runtime_size);
         initialize_memory(any_value.value_pointer, any_value.type);

--- a/src/deserialize.jai
+++ b/src/deserialize.jai
@@ -49,8 +49,8 @@ value_to_type :: (toml: Value, slot: *void, info: *Type_Info, parent_name:string
         expect(toml.type, .TABLE, parent_name, name);
         struct_info :*Type_Info_Struct= xx info;
 
-        if array_find(struct_info.notes, "TaggedUnion") {
-            return value_to_tagged_union(toml.table, slot, struct_info, parent_name);
+        if array_find(struct_info.notes, "SumType") {
+            return value_to_sumtype(toml.table, slot, struct_info, parent_name);
         }
         for member: struct_info.members {
             if member.flags & (.CONSTANT |.IMPORTED) continue;
@@ -159,22 +159,22 @@ value_to_chrono ::  (toml: Value, slot: *void, info: *Type_Info) -> is_chrono:bo
     return false;
 }
 
-value_to_tagged_union :: (toml_table: []KeyValue, slot: *void, struct_info: *Type_Info_Struct, parent_name: string) -> ok:=false {
-    valid, tag_member, union_member, tag_info, union_info:= is_valid_tagged_union(struct_info);
-    if !valid { return_with_error("Tagged Union % is not valid", struct_info.name); }
+value_to_sumtype :: (toml_table: []KeyValue, slot: *void, struct_info: *Type_Info_Struct, parent_name: string) -> ok:=false {
+    valid, tag_member, union_member, tag_info, union_info:= is_valid_sumtype(struct_info);
+    if !valid { return_with_error("SumType % is not valid", struct_info.name); }
 
     if toml_table.count == 0  return true; // Empty table, nothing to do
-    if toml_table.count != 1  return_with_error("Tagged Union % should have exactly one key-value pair", struct_info.name);
+    if toml_table.count != 1  return_with_error("SumType % should have exactly one key-value pair", struct_info.name);
 
     for tag_info.names if it == toml_table[0].key {
         set_enum_value(slot + tag_member.offset_in_bytes, tag_info, tag_info.values[it_index]);
         active_variant:= union_info.members[it_index];
         return value_to_type(toml_table[0].value, slot + union_member.offset_in_bytes + active_variant.offset_in_bytes, active_variant.type, parent_name, toml_table[0].key);
     }
-    return_with_error("Key % is not an enum variant of Tagged Union %", toml_table[0].key, struct_info.name);
+    return_with_error("Key % is not an enum variant of SumType %", toml_table[0].key, struct_info.name);
 }
 
-is_valid_tagged_union :: (struct_info: *Type_Info_Struct) -> bool, tag_member:*Type_Info_Struct_Member=null, union_member:*Type_Info_Struct_Member=null, tag_info:*Type_Info_Enum=null, union_info:*Type_Info_Struct=null {
+is_valid_sumtype :: (struct_info: *Type_Info_Struct) -> bool, tag_member:*Type_Info_Struct_Member=null, union_member:*Type_Info_Struct_Member=null, tag_info:*Type_Info_Enum=null, union_info:*Type_Info_Struct=null {
     if struct_info.members.count != 2                                      return false;
     tag_member, union_member:= *struct_info.members[0], *struct_info.members[1];
     if tag_member.type.type != .ENUM || union_member.type.type != .STRUCT  return false;

--- a/src/deserialize.jai
+++ b/src/deserialize.jai
@@ -45,30 +45,20 @@ value_to_type :: (toml: Value, slot: *void, info: *Type_Info, parent_name:string
         if toml.table.count != 0 { return_with_error("Expected empty table for %.%, got %", parent_name, name, toml.table.count);  }
     case .STRUCT;
         if value_to_chrono(toml, slot, info) return true;
+
         expect(toml.type, .TABLE, parent_name, name);
+        struct_info :*Type_Info_Struct= xx info;
 
-        add_members :: (table: []KeyValue, slot: *void, struct_info: *Type_Info_Struct, parent_name: string, name: string) -> ok:=false {
-             if array_find(struct_info.notes, "TaggedUnion") {
-                return value_to_tagged_union(table, slot, struct_info, parent_name);
-            }
-
-            for member: struct_info.members {
-                if member.flags & (.CONSTANT |.IMPORTED) continue;
-                if member.name == "" { // Anonymous using
-                    if member.type.type != .STRUCT then return_with_error("Type with anonymous using of non-structs is not supported"); // Anonymous pointers / enums
-                    ok:= add_members(table, slot + member.offset_in_bytes, xx member.type, parent_name, name);  if !ok return;
-                    continue;
-                }
-
-                for table if it.key == member.name {
-                    ok:= value_to_type(it.value, slot + member.offset_in_bytes, member.type, parent_name, member.name);  if !ok return;
-                    break;
-                }
-            }
-            return true;
+        if array_find(struct_info.notes, "TaggedUnion") {
+            return value_to_tagged_union(toml.table, slot, struct_info, parent_name);
         }
-        ok:= add_members(toml.table, slot, xx info, parent_name, name);  if !ok return;
-
+        for member: struct_info.members {
+            if member.flags & (.CONSTANT |.IMPORTED) continue;
+            for toml.table if it.key == member.name {
+                ok:= value_to_type(it.value, slot + member.offset_in_bytes, member.type, parent_name, member.name);  if !ok return;
+                break;
+            }
+        }
     case .ARRAY;
         expect(toml.type, .ARRAY, parent_name, name);
         array_info :*Type_Info_Array= xx info;
@@ -169,18 +159,6 @@ value_to_chrono ::  (toml: Value, slot: *void, info: *Type_Info) -> is_chrono:bo
     return false;
 }
 
-is_valid_tagged_union :: (struct_info: *Type_Info_Struct) -> bool, tag_member:*Type_Info_Struct_Member=null, union_member:*Type_Info_Struct_Member=null, tag_info:*Type_Info_Enum=null, union_info:*Type_Info_Struct=null {
-    if !array_find(struct_info.notes, "TaggedUnion")                       return false;
-    if struct_info.members.count != 2                                      return false;
-    tag_member, union_member:= *struct_info.members[0], *struct_info.members[1];
-    if tag_member.type.type != .ENUM || union_member.type.type != .STRUCT  return false;
-    tag_info :*Type_Info_Enum= xx tag_member.type;
-    union_info :*Type_Info_Struct= xx union_member.type;
-    if union_info.textual_flags & .UNION == 0                              return false;
-    if tag_info.values.count != union_info.members.count                   return false;
-    return true, tag_member, union_member, tag_info, union_info;
-}
-
 value_to_tagged_union :: (toml_table: []KeyValue, slot: *void, struct_info: *Type_Info_Struct, parent_name: string) -> ok:=false {
     valid, tag_member, union_member, tag_info, union_info:= is_valid_tagged_union(struct_info);
     if !valid { return_with_error("Tagged Union % is not valid", struct_info.name); }
@@ -194,6 +172,17 @@ value_to_tagged_union :: (toml_table: []KeyValue, slot: *void, struct_info: *Typ
         return value_to_type(toml_table[0].value, slot + union_member.offset_in_bytes + active_variant.offset_in_bytes, active_variant.type, parent_name, toml_table[0].key);
     }
     return_with_error("Key % is not an enum variant of Tagged Union %", toml_table[0].key, struct_info.name);
+}
+
+is_valid_tagged_union :: (struct_info: *Type_Info_Struct) -> bool, tag_member:*Type_Info_Struct_Member=null, union_member:*Type_Info_Struct_Member=null, tag_info:*Type_Info_Enum=null, union_info:*Type_Info_Struct=null {
+    if struct_info.members.count != 2                                      return false;
+    tag_member, union_member:= *struct_info.members[0], *struct_info.members[1];
+    if tag_member.type.type != .ENUM || union_member.type.type != .STRUCT  return false;
+    tag_info :*Type_Info_Enum= xx tag_member.type;
+    union_info :*Type_Info_Struct= xx union_member.type;
+    if union_info.textual_flags & .UNION == 0                              return false;
+    if tag_info.values.count != union_info.members.count                   return false;
+    return true, tag_member, union_member, tag_info, union_info;
 }
 
 expect :: inline (given: Value.Type, expected: Value.Type, struct_name: string, member_name: string) #expand {

--- a/src/deserialize.jai
+++ b/src/deserialize.jai
@@ -47,14 +47,28 @@ value_to_type :: (toml: Value, slot: *void, info: *Type_Info, parent_name:string
         if value_to_chrono(toml, slot, info) return true;
         expect(toml.type, .TABLE, parent_name, name);
 
-        members := flat_members(xx info); defer array_free(members);
-        for member: members if !(member.flags & .USING && member.type.type == .STRUCT) {
-            for toml.table if it.key == member.name {
-                ok := value_to_type(it.value, slot + member.offset_in_bytes, member.type, parent_name, member.name); if !ok return;
-                break; // TODO catch multiple members from the same union, works but leaky, will also needed to determine required members are set
+        add_members :: (table: []KeyValue, slot: *void, struct_info: *Type_Info_Struct, parent_name: string, name: string) -> ok:=false {
+             if array_find(struct_info.notes, "TaggedUnion") {
+                return value_to_tagged_union(table, slot, struct_info, parent_name);
             }
+
+            for member: struct_info.members {
+                if member.flags & (.CONSTANT |.IMPORTED) continue;
+                if member.name == "" { // Anonymous using
+                    if member.type.type != .STRUCT then return_with_error("Type with anonymous using of non-structs is not supported"); // Anonymous pointers / enums
+                    ok:= add_members(table, slot + member.offset_in_bytes, xx member.type, parent_name, name);  if !ok return;
+                    continue;
+                }
+
+                for table if it.key == member.name {
+                    ok:= value_to_type(it.value, slot + member.offset_in_bytes, member.type, parent_name, member.name);  if !ok return;
+                    break;
+                }
+            }
+            return true;
         }
-        ok := enforce_uniontag_note(toml.table, slot, members, parent_name); if !ok return;
+        ok:= add_members(toml.table, slot, xx info, parent_name, name);  if !ok return;
+
     case .ARRAY;
         expect(toml.type, .ARRAY, parent_name, name);
         array_info :*Type_Info_Array= xx info;
@@ -155,45 +169,31 @@ value_to_chrono ::  (toml: Value, slot: *void, info: *Type_Info) -> is_chrono:bo
     return false;
 }
 
-// Collect all variables members and flattens using structs incl. unions, keeps original using members as well, needed for uniontag
-flat_members :: (info:*Type_Info_Struct) -> [..]Type_Info_Struct_Member { // TODO change to for_expansion?
-    flat_members :: (flattened:*[..]Type_Info_Struct_Member, info:*Type_Info_Struct, offset_in_bytes: s64) {
-        for member: info.members {
-            if member.flags & .CONSTANT { continue; }
-            if member.flags & .USING && member.type.type == .STRUCT { // NOTE: Enums and pointers can be using too
-                flat_members(flattened, xx member.type, offset_in_bytes + member.offset_in_bytes);
-            }
-            array_add(flattened, member);
-            peek_pointer(flattened.*).offset_in_bytes += offset_in_bytes;
-        }
-    }
-    flattened: [..]Type_Info_Struct_Member;
-    flat_members(*flattened, info, 0);
-    return flattened;
+is_valid_tagged_union :: (struct_info: *Type_Info_Struct) -> bool, tag_member:*Type_Info_Struct_Member=null, union_member:*Type_Info_Struct_Member=null, tag_info:*Type_Info_Enum=null, union_info:*Type_Info_Struct=null {
+    if !array_find(struct_info.notes, "TaggedUnion")                       return false;
+    if struct_info.members.count != 2                                      return false;
+    tag_member, union_member:= *struct_info.members[0], *struct_info.members[1];
+    if tag_member.type.type != .ENUM || union_member.type.type != .STRUCT  return false;
+    tag_info :*Type_Info_Enum= xx tag_member.type;
+    union_info :*Type_Info_Struct= xx union_member.type;
+    if union_info.textual_flags & .UNION == 0                              return false;
+    if tag_info.values.count != union_info.members.count                   return false;
+    return true, tag_member, union_member, tag_info, union_info;
 }
 
-enforce_uniontag_note :: (toml_table: []KeyValue, slot: *void, flat_members: []Type_Info_Struct_Member, parent_name: string) -> ok:=false {
-    for member: flat_members {
-        // Find union member with @UnionTag note
-        if member.type.type != .STRUCT continue;
-        member_info :*Type_Info_Struct= xx member.type;
-        if !(member_info.textual_flags & .UNION) continue;
-        tag_name: string;
-        for note: member.notes if begins_with(note, "UnionTag:") { tag_name = slice(note, 9, note.count-9); break; }
-        if !tag_name continue;
+value_to_tagged_union :: (toml_table: []KeyValue, slot: *void, struct_info: *Type_Info_Struct, parent_name: string) -> ok:=false {
+    valid, tag_member, union_member, tag_info, union_info:= is_valid_tagged_union(struct_info);
+    if !valid { return_with_error("Tagged Union % is not valid", struct_info.name); }
 
-        // Find it's tag member
-        tag : *Type_Info_Struct_Member;
-        for * flat_members if it.name == tag_name { tag = it; break; }
-        assert(tag!=null, "Union %.%'s tag member `%` cannot be found", parent_name, member.name, tag_name);
+    if toml_table.count == 0  return true; // Empty table, nothing to do
+    if toml_table.count != 1  return_with_error("Tagged Union % should have exactly one key-value pair", struct_info.name);
 
-        // Determine which union member is was set (if any) and set the tag to its index
-        for #v2 < union_member, union_idx: member_info.members for toml_table if it.key == union_member.name { // Reverse in case of multiple
-            ok := value_to_type(.{type=.INT, int_value=union_idx}, slot + tag.offset_in_bytes, tag.type, parent_name, union_member.name); if !ok return;
-            break union_member;
-        }
+    for tag_info.names if it == toml_table[0].key {
+        set_enum_value(slot + tag_member.offset_in_bytes, tag_info, tag_info.values[it_index]);
+        active_variant:= union_info.members[it_index];
+        return value_to_type(toml_table[0].value, slot + union_member.offset_in_bytes + active_variant.offset_in_bytes, active_variant.type, parent_name, toml_table[0].key);
     }
-    return true;
+    return_with_error("Key % is not an enum variant of Tagged Union %", toml_table[0].key, struct_info.name);
 }
 
 expect :: inline (given: Value.Type, expected: Value.Type, struct_name: string, member_name: string) #expand {

--- a/src/parser.jai
+++ b/src/parser.jai
@@ -78,7 +78,7 @@ parse_key :: (parent: *Value, scope: Scope) -> ok:=false, leaf:*Value=null, leaf
 }
 
 // * current_table is null for values in arrays
-parse_value :: (current_table: *Value, scope: *Scope) -> ok:=false, value:Value=.{} { // TODO only assign value if key is empty table
+parse_value :: (current_table: *Value, scope: *Scope) -> ok:=false, value:Value=.{} {
     if !has_next(scope) { return_with_error("Unexpected end of file while parsing value"); }
 
     token := peek_token(scope);

--- a/src/serialize.jai
+++ b/src/serialize.jai
@@ -44,17 +44,22 @@ type_to_value :: (slot: *void, info: *Type_Info) -> ok:=false, toml:Value=.{} {
         // Unlike Basic.print we do re-print all overlapping #place members. This will output the same data multiple times, but is likely more predictable.
         // Otherwise we would need to keep track of the offset is always increase compared to the highest offset.
         add_members :: (table: *[..]KeyValue, struct_info: *Type_Info_Struct, slot: *void) -> ok:=false { // swap slot and info
+            log("name %", struct_info.name);
+            for struct_info.notes  log("note %", it);
             if array_find(struct_info.notes, "TaggedUnion") {
+                log("asd2");
                 ok, union_keyvalue:= tagged_union_to_keyvalue(slot, struct_info);  if !ok return;
                 array_add(table, union_keyvalue);
                 return true;
             }
+            if struct_info.textual_flags & .UNION return_with_error("Untagged unions (%) are not supported, as we cannot determine the active member, use @TaggedUnion", ifx struct_info.name then struct_info.name else "anonymous");
+
             for member: struct_info.members {
                 if member.flags & (.CONSTANT | .IMPORTED)              continue;
                 if is_null(slot + member.offset_in_bytes, member.type) continue;
                 if member.name == "" { // Anonymous using
                     if member.type.type != .STRUCT then return_with_error("Type with anonymous using of non-structs is not supported"); // Anonymous pointers / enums
-                    add_members(table, cast(*Type_Info_Struct, member.type), slot + member.offset_in_bytes);
+                    ok:= add_members(table, cast(*Type_Info_Struct, member.type), slot + member.offset_in_bytes); if !ok return;
                     continue;
                 }
                 ok, member_value:= type_to_value(slot + member.offset_in_bytes, member.type);  if !ok return;
@@ -118,7 +123,8 @@ tagged_union_to_keyvalue :: (slot: *void, struct_info: *Type_Info_Struct) -> ok:
     // can be custom sum-type null
 
     ok, union_value:= type_to_value(slot + union_member.offset_in_bytes + active_variant.offset_in_bytes, active_variant.type); if !ok return;
-    return true, .{key=tag_info.names[active_tag_idx], value=union_value};
+    active_tag_name:= tag_info.names[active_tag_idx]; // We use the enums string name as the union member may be anonymous
+    return true, .{key=active_tag_name, value=union_value};
 }
 
 is_null :: (slot: *void, info: *Type_Info) -> bool {

--- a/src/serialize.jai
+++ b/src/serialize.jai
@@ -41,31 +41,21 @@ type_to_value :: (slot: *void, info: *Type_Info) -> ok:=false, toml:Value=.{} {
         case type_info(DateTimeOffset); return true, .{type=.DATETIME, datetime=.{type=.OFFSET_DATETIME, datetime_offset=cast(*DateTimeOffset, slot).*}};
         }
 
-        // Unlike Basic.print we do re-print all overlapping #place members. This will output the same data multiple times, but is likely more predictable.
-        // Otherwise we would need to keep track of the offset is always increase compared to the highest offset.
-        add_members :: (table: *[..]KeyValue, struct_info: *Type_Info_Struct, slot: *void) -> ok:=false { // swap slot and info
-            if array_find(struct_info.notes, "TaggedUnion") {
-                ok, union_keyvalue:= tagged_union_to_keyvalue(slot, struct_info);  if !ok return;
-                array_add(table, union_keyvalue);
-                return true;
-            }
-            if struct_info.textual_flags & .UNION return_with_error("Untagged unions (%) are not supported, as we cannot determine the active member, use @TaggedUnion", ifx struct_info.name then struct_info.name else "anonymous");
-
-            for member: struct_info.members {
-                if member.flags & (.CONSTANT | .IMPORTED)              continue;
-                if is_null(slot + member.offset_in_bytes, member.type) continue;
-                if member.name == "" { // Anonymous using
-                    if member.type.type != .STRUCT then return_with_error("Type with anonymous using of non-structs is not supported"); // Anonymous pointers / enums
-                    ok:= add_members(table, xx member.type, slot + member.offset_in_bytes); if !ok return;
-                    continue;
-                }
-                ok, member_value:= type_to_value(slot + member.offset_in_bytes, member.type);  if !ok return;
-                array_add(table, KeyValue.{key=member.name, value=member_value});
-            }
-            return true;
+        if array_find(struct_info.notes, "TaggedUnion") {
+            ok, union_keyvalue:= tagged_union_to_keyvalue(slot, struct_info);  if !ok return;
+            return true, .{type=.TABLE, table=resizable(KeyValue.[union_keyvalue])};
         }
+        if struct_info.textual_flags & .UNION return_with_error("Untagged unions (%) are not supported, as we cannot determine the active member, use @TaggedUnion", ifx struct_info.name then struct_info.name else "anonymous");
+
+        // Unlike Basic.print we do re-print all overlapping #place members. This will output the same data multiple times, but is likely more predictable.
+        // Otherwise we would need to recursively track the offset is always increase compared to the highest offset.
         table: [..]KeyValue;
-        ok:= add_members(*table, struct_info, slot);  if !ok return;
+        for member: struct_info.members {
+            if member.flags & (.CONSTANT | .IMPORTED)              continue;
+            if is_null(slot + member.offset_in_bytes, member.type) continue;
+            ok, member_value:= type_to_value(slot + member.offset_in_bytes, member.type);  if !ok return;
+            array_add(*table, KeyValue.{key=member.name, value=member_value});
+        }
         return true, .{type=.TABLE, table=table};
     case .ARRAY;
         array_info :*Type_Info_Array= xx info;

--- a/src/serialize.jai
+++ b/src/serialize.jai
@@ -31,7 +31,8 @@ type_to_value :: (slot: *void, info: *Type_Info) -> ok:=false, toml:Value=.{} {
         return ok, value;
     case .VOID;  return true, .{};
     case .STRUCT;
-        if info == {
+        struct_info :*Type_Info_Struct= xx info;
+        if struct_info == {
         case type_info(Value);          return true, cast(*Value, slot).*; // No deep copy!
         case type_info(Chrono);         return true, .{type=.DATETIME, datetime=cast(*Chrono, slot).*};
         case type_info(Time);           return true, .{type=.DATETIME, datetime=.{type=.LOCAL_TIME,      time=           cast(*Time, slot).*}};
@@ -39,35 +40,49 @@ type_to_value :: (slot: *void, info: *Type_Info) -> ok:=false, toml:Value=.{} {
         case type_info(DateTime);       return true, .{type=.DATETIME, datetime=.{type=.LOCAL_DATETIME,  datetime=       cast(*DateTime, slot).*}};
         case type_info(DateTimeOffset); return true, .{type=.DATETIME, datetime=.{type=.OFFSET_DATETIME, datetime_offset=cast(*DateTimeOffset, slot).*}};
         }
-        flattened := flat_nonnull_members(slot, xx info);
-        replace_uniontag(slot, *flattened);
 
-        table: [..]KeyValue;
-        array_reserve(*table, flattened.count);
-        for member: flattened {
-            ok, value := type_to_value(slot + member.offset_in_bytes, member.type); if !ok return;
-            kv := KeyValue.{key=member.name, value=value};
-            array_add(*table, kv);
+        // Unlike Basic.print we do re-print all overlapping #place members. This will output the same data multiple times, but is likely more predictable.
+        // Otherwise we would need to keep track of the offset is always increase compared to the highest offset.
+        add_members :: (table: *[..]KeyValue, struct_info: *Type_Info_Struct, slot: *void) -> ok:=false { // swap slot and info
+            if array_find(struct_info.notes, "TaggedUnion") {
+                ok, union_keyvalue:= tagged_union_to_keyvalue(slot, struct_info);  if !ok return;
+                array_add(table, union_keyvalue);
+                return true;
+            }
+            for member: struct_info.members {
+                if member.flags & (.CONSTANT | .IMPORTED)              continue;
+                if is_null(slot + member.offset_in_bytes, member.type) continue;
+                if member.name == "" { // Anonymous using
+                    if member.type.type != .STRUCT then return_with_error("Type with anonymous using of non-structs is not supported"); // Anonymous pointers / enums
+                    add_members(table, cast(*Type_Info_Struct, member.type), slot + member.offset_in_bytes);
+                    continue;
+                }
+                ok, member_value:= type_to_value(slot + member.offset_in_bytes, member.type);  if !ok return;
+                array_add(table, KeyValue.{key=member.name, value=member_value});
+            }
+            return true;
         }
+        table: [..]KeyValue;
+        add_members(*table, struct_info, slot);
         return true, .{type=.TABLE, table=table};
     case .ARRAY;
         array_info :*Type_Info_Array= xx info;
-        array_count  := ifx array_info.array_type == .FIXED then array_info.array_count else cast(*s64,   slot).*;
-        array_slot   := ifx array_info.array_type == .FIXED then slot                   else cast(**void, slot+8).*;
+        array_count:= ifx array_info.array_type == .FIXED then array_info.array_count else cast(*s64,   slot).*;
+        array_slot := ifx array_info.array_type == .FIXED then slot                   else cast(**void, slot+8).*;
 
         array: [..]Value;
         array_reserve(*array, array_count);
         for idx: 0..array_count-1 {
-            element_slot := array_slot + array_info.element_type.runtime_size * idx;
+            element_slot:= array_slot + array_info.element_type.runtime_size * idx;
             if is_null(element_slot, array_info.element_type) return_with_error("Null pointer in array detected which is not supported");
-            ok, v := type_to_value(element_slot, array_info.element_type); if !ok return;
-            array_add(*array, v);
+            ok, record_value:= type_to_value(element_slot, array_info.element_type); if !ok return;
+            array_add(*array, record_value);
         }
         return true, .{type=.ARRAY, array=array};
     case .ANY;
         any_value :*Any_Struct= xx slot;
         assert(any_value.value_pointer != null, "Implementation error: null pointers should be filtered out");
-        ok, value := type_to_value(any_value.value_pointer, any_value.type);
+        ok, value:= type_to_value(any_value.value_pointer, any_value.type);
         return ok, value;
     case .ENUM;
         enum_info :*Type_Info_Enum= xx info;
@@ -76,7 +91,7 @@ type_to_value :: (slot: *void, info: *Type_Info) -> ok:=false, toml:Value=.{} {
         }
         assert(false, "Enum value % not found in enum %", get_enum_value(slot, enum_info), enum_info.name);
     case .VARIANT;
-        ok, value := type_to_value(slot, cast(*Type_Info_Variant, info).variant_of);
+        ok, value:= type_to_value(slot, cast(*Type_Info_Variant, info).variant_of);
         return ok, value;
     case .PROCEDURE;            #through;
     case .OVERLOAD_SET;         #through;
@@ -87,6 +102,29 @@ type_to_value :: (slot: *void, info: *Type_Info) -> ok:=false, toml:Value=.{} {
     case .UNTYPED_ENUM;
     }
     return_with_error("Parsing of type % is not supported", info.type);
+}
+
+tagged_union_to_keyvalue :: (slot: *void, struct_info: *Type_Info_Struct) -> ok:=false, keyvalue:KeyValue=.{} {
+    // TODO asserts
+    tag_member:= struct_info.members[0];
+    union_member:= struct_info.members[1];
+    tag_info :*Type_Info_Enum= xx tag_member.type;
+    union_info :*Type_Info_Struct= xx union_member.type;
+    assert(tag_member.type.type == .ENUM);
+    active_tag_idx := get_enum_value(slot + tag_member.offset_in_bytes, xx tag_member.type);
+    active_variant := union_info.members[active_tag_idx];
+
+    // if is_null(slot + member.offset_in_bytes, member.type) continue; TODO
+    // can be custom sum-type null
+
+    ok, union_value:= type_to_value(slot + union_member.offset_in_bytes + active_variant.offset_in_bytes, active_variant.type); if !ok return;
+    return true, .{key=tag_info.names[active_tag_idx], value=union_value};
+}
+
+is_null :: (slot: *void, info: *Type_Info) -> bool {
+    if info.type == .POINTER return cast(**void, slot).* == null;
+    if info.type == .ANY     return cast(*Any_Struct, slot).value_pointer == null;
+    return false;
 }
 
 serialize :: (builder: *String_Builder, value: Value, parent_key: string = "") {
@@ -170,67 +208,6 @@ print_to_builder_escaped :: (builder: *String_Builder, str: string, $is_key: boo
         case;              append(builder, it);
     }
     append(builder, "\"");
-}
-
-// Collect all variables members and flattens using structs incl. unions, keeps original using members as well, needed for uniontag
-flat_nonnull_members :: (slot: *void, info:*Type_Info_Struct) -> [..]Type_Info_Struct_Member {
-    flat_nonnull_members :: (slot: *void, flattened:*[..]Type_Info_Struct_Member, info:*Type_Info_Struct, offset_in_bytes: s64) {
-        for member: info.members {
-            if member.flags & .CONSTANT continue;
-            if member.flags & .IMPORTED continue;
-            // VOID members are written as empty tables, may be needed for unions
-            // Unlike Basic.print we do re-print all overlapping #place members. This will output the same data multiple times, but is likely more predictable.
-            // Otherwise we would need to keep track of the offset is always increase compared to the highest offset.
-            if member.flags & .USING && member.type.type == .STRUCT { // NOTE: Enums can be using too
-                member_info: *Type_Info_Struct = xx member.type;
-                if !(member_info.textual_flags & .UNION) {
-                    flat_nonnull_members(slot, flattened, xx member.type, offset_in_bytes + member.offset_in_bytes);
-                    continue;
-                }
-            }
-            if is_null(slot + offset_in_bytes + member.offset_in_bytes, member.type) continue;
-            array_add(flattened, member);
-            peek_pointer(flattened.*).offset_in_bytes += offset_in_bytes;
-        }
-    }
-    flattened: [..]Type_Info_Struct_Member;
-    flat_nonnull_members(slot, *flattened, info, 0);
-    return flattened;
-}
-
-replace_uniontag :: (slot: *void, flattened:*[..]Type_Info_Struct_Member) {
-    index := flattened.count-1;
-    while outer:= index >= 0 {
-        defer index -= 1;
-        member := flattened.*[index];
-        // Find union member with @UnionTag note
-        if member.type.type != .STRUCT continue;
-        member_info := cast(*Type_Info_Struct, member.type);
-        if !(member_info.textual_flags & .UNION) continue;
-        tag_name: string;
-        for note: member.notes if begins_with(note, "UnionTag:") { tag_name = slice(note, 9, note.count-9); break; }
-        assert(tag_name!="", "Cannot serialize union without knowing which variant is active, @UnionTag:[member_name] is missing");
-
-        // Remove it's tag member, replace union by its active variant
-        for flattened.* if it.name == tag_name { // find instead of loop
-            assert(it.type.type == .ENUM);
-            tag_idx := get_enum_value(slot + it.offset_in_bytes, xx it.type);
-            current_variant := member_info.members[tag_idx];
-            current_variant.offset_in_bytes += member.offset_in_bytes;
-            flattened.*[index] = current_variant;
-
-            array_ordered_remove_by_index(flattened, it_index);
-            if it_index < index { index -= 1; }
-            continue outer;
-        }
-        assert(false, "Union .%'s tag member `%` cannot be found", member.name, tag_name);
-    }
-}
-
-is_null :: (slot: *void, info: *Type_Info) -> bool {
-    if info.type == .POINTER return cast(**void, slot).* == null;
-    if info.type == .ANY     return cast(*Any_Struct, slot).value_pointer == null;
-    return false;
 }
 
 // true if it would otherwise introduce additional braces or brackets, so no in-line tables or arrays in in-line tables,

--- a/src/serialize.jai
+++ b/src/serialize.jai
@@ -100,13 +100,12 @@ sumtype_to_keyvalue :: (slot: *void, struct_info: *Type_Info_Struct) -> ok:=fals
     valid, tag_member, union_member, tag_info, union_info:= is_valid_sumtype(struct_info);
     if !valid { return_with_error("SumType % is not valid", struct_info.name); }
 
-    active_tag_idx := get_enum_value(slot + tag_member.offset_in_bytes, xx tag_member.type);
-    active_variant := union_info.members[active_tag_idx];
+    active_tag_idx:= get_enum_value(slot + tag_member.offset_in_bytes, xx tag_member.type);
+    active_variant:= union_info.members[active_tag_idx];
+    variant_slot:= slot + union_member.offset_in_bytes + active_variant.offset_in_bytes;
+    if is_null(variant_slot, active_variant.type) return_with_error("Null pointer in SumType detected which is not supported");
 
-    // if is_null(slot + member.offset_in_bytes, member.type) continue; TODO
-    // can be custom sum-type null
-
-    ok, union_value:= type_to_value(slot + union_member.offset_in_bytes + active_variant.offset_in_bytes, active_variant.type); if !ok return;
+    ok, union_value:= type_to_value(variant_slot, active_variant.type); if !ok return;
     active_tag_name:= tag_info.names[active_tag_idx]; // We use the enums string name as the union member may be anonymous
     return true, .{key=active_tag_name, value=union_value};
 }

--- a/src/serialize.jai
+++ b/src/serialize.jai
@@ -44,10 +44,7 @@ type_to_value :: (slot: *void, info: *Type_Info) -> ok:=false, toml:Value=.{} {
         // Unlike Basic.print we do re-print all overlapping #place members. This will output the same data multiple times, but is likely more predictable.
         // Otherwise we would need to keep track of the offset is always increase compared to the highest offset.
         add_members :: (table: *[..]KeyValue, struct_info: *Type_Info_Struct, slot: *void) -> ok:=false { // swap slot and info
-            log("name %", struct_info.name);
-            for struct_info.notes  log("note %", it);
             if array_find(struct_info.notes, "TaggedUnion") {
-                log("asd2");
                 ok, union_keyvalue:= tagged_union_to_keyvalue(slot, struct_info);  if !ok return;
                 array_add(table, union_keyvalue);
                 return true;
@@ -59,7 +56,7 @@ type_to_value :: (slot: *void, info: *Type_Info) -> ok:=false, toml:Value=.{} {
                 if is_null(slot + member.offset_in_bytes, member.type) continue;
                 if member.name == "" { // Anonymous using
                     if member.type.type != .STRUCT then return_with_error("Type with anonymous using of non-structs is not supported"); // Anonymous pointers / enums
-                    ok:= add_members(table, cast(*Type_Info_Struct, member.type), slot + member.offset_in_bytes); if !ok return;
+                    ok:= add_members(table, xx member.type, slot + member.offset_in_bytes); if !ok return;
                     continue;
                 }
                 ok, member_value:= type_to_value(slot + member.offset_in_bytes, member.type);  if !ok return;
@@ -110,12 +107,9 @@ type_to_value :: (slot: *void, info: *Type_Info) -> ok:=false, toml:Value=.{} {
 }
 
 tagged_union_to_keyvalue :: (slot: *void, struct_info: *Type_Info_Struct) -> ok:=false, keyvalue:KeyValue=.{} {
-    // TODO asserts
-    tag_member:= struct_info.members[0];
-    union_member:= struct_info.members[1];
-    tag_info :*Type_Info_Enum= xx tag_member.type;
-    union_info :*Type_Info_Struct= xx union_member.type;
-    assert(tag_member.type.type == .ENUM);
+    valid, tag_member, union_member, tag_info, union_info:= is_valid_tagged_union(struct_info);
+    if !valid { return_with_error("Tagged Union % is not valid", struct_info.name); }
+
     active_tag_idx := get_enum_value(slot + tag_member.offset_in_bytes, xx tag_member.type);
     active_variant := union_info.members[active_tag_idx];
 

--- a/src/serialize.jai
+++ b/src/serialize.jai
@@ -63,7 +63,7 @@ type_to_value :: (slot: *void, info: *Type_Info) -> ok:=false, toml:Value=.{} {
             return true;
         }
         table: [..]KeyValue;
-        add_members(*table, struct_info, slot);
+        ok:= add_members(*table, struct_info, slot);  if !ok return;
         return true, .{type=.TABLE, table=table};
     case .ARRAY;
         array_info :*Type_Info_Array= xx info;

--- a/src/serialize.jai
+++ b/src/serialize.jai
@@ -41,11 +41,11 @@ type_to_value :: (slot: *void, info: *Type_Info) -> ok:=false, toml:Value=.{} {
         case type_info(DateTimeOffset); return true, .{type=.DATETIME, datetime=.{type=.OFFSET_DATETIME, datetime_offset=cast(*DateTimeOffset, slot).*}};
         }
 
-        if array_find(struct_info.notes, "TaggedUnion") {
-            ok, union_keyvalue:= tagged_union_to_keyvalue(slot, struct_info);  if !ok return;
+        if array_find(struct_info.notes, "SumType") {
+            ok, union_keyvalue:= sumtype_to_keyvalue(slot, struct_info);  if !ok return;
             return true, .{type=.TABLE, table=resizable(KeyValue.[union_keyvalue])};
         }
-        if struct_info.textual_flags & .UNION return_with_error("Untagged unions (%) are not supported, as we cannot determine the active member, use @TaggedUnion", ifx struct_info.name then struct_info.name else "anonymous");
+        if struct_info.textual_flags & .UNION return_with_error("Untagged unions (%) are not supported, as we cannot determine the active member, use @SumType", ifx struct_info.name then struct_info.name else "anonymous");
 
         // Unlike Basic.print we do re-print all overlapping #place members. This will output the same data multiple times, but is likely more predictable.
         // Otherwise we would need to recursively track the offset is always increase compared to the highest offset.
@@ -96,9 +96,9 @@ type_to_value :: (slot: *void, info: *Type_Info) -> ok:=false, toml:Value=.{} {
     return_with_error("Parsing of type % is not supported", info.type);
 }
 
-tagged_union_to_keyvalue :: (slot: *void, struct_info: *Type_Info_Struct) -> ok:=false, keyvalue:KeyValue=.{} {
-    valid, tag_member, union_member, tag_info, union_info:= is_valid_tagged_union(struct_info);
-    if !valid { return_with_error("Tagged Union % is not valid", struct_info.name); }
+sumtype_to_keyvalue :: (slot: *void, struct_info: *Type_Info_Struct) -> ok:=false, keyvalue:KeyValue=.{} {
+    valid, tag_member, union_member, tag_info, union_info:= is_valid_sumtype(struct_info);
+    if !valid { return_with_error("SumType % is not valid", struct_info.name); }
 
     active_tag_idx := get_enum_value(slot + tag_member.offset_in_bytes, xx tag_member.type);
     active_variant := union_info.members[active_tag_idx];


### PR DESCRIPTION
- Changed @UnionTag to @SumType on the struct
- Restructured examples
- Added note on Apollo.Calendar_Time
- Using members are now required, incl anonymous members! -> ""
- Any no longer attempts to make a homogenous array instead just makes an array of Toml.Value