### PR TITLE
Custom handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TOML-jai
 
+![](https://img.shields.io/badge/Jai-beta%200.2.008-blue.svg)
+
 A module for `TOML v1.0.0` support. It provides functionality to read/write TOML files and convert them directly to/from Jai data structures.
 
 - Full TOML v1.0.0 support.
@@ -8,8 +10,6 @@ A module for `TOML v1.0.0` support. It provides functionality to read/write TOML
 - Dates/times are supported types provided in [src/datetime.jai](src/datetime.jai) (until Jai has native types, Apollo_time.Calendar_Time is not usable here).
 - Safe sum-types with `@SumType` notes to indicate the struct has a tag enum followed by a matching union.
 - There is currently no way to provide an alternative (de)serialization procedures for a user-defined type (e.g. Jai's Tagged_Union would serialize as an array of u8 numbers and the contents of the Type_Info)
-
-Latest confirmed compatible Jai Version: beta 0.2.008, built on 14 January 2025.
 
 ## Deserialize
 `ok, my_struct := Toml.deserialize(toml_string, My_Struct);`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A module for `TOML v1.0.0` support. It provides functionality to read/write TOML
 - Generic data is supported through the [Toml.Value](src/data.jai) struct.
 - Dates/times are supported types provided in [src/datetime.jai](src/datetime.jai) (until Jai has native types, Apollo_time.Calendar_Time is not usable here).
 - Safe sum-types with `@SumType` notes to indicate the struct has a tag enum followed by a matching union.
-- There is currently no way to provide an alternative (de)serialization procedures for a user-defined type (e.g. Jai's Tagged_Union would serialize as an array of u8 numbers and the contents of the Type_Info)
+- Modifying the default behavior, like renaming, omitting, changing Type representation like enum as int, extra validation, or handling complex data like binary encodings are supported through [custom handlers](examples/custom_handlers.jai). 
 
 ## Deserialize
 `ok, my_struct := Toml.deserialize(toml_string, My_Struct);`
@@ -41,6 +41,30 @@ The lifetime of all returned objects ends when the memory of the allocator is re
 - Most temporarily allocated memory in the module is freed in one go by releasing a pool allocator.
 - In most cases this means that only the returned data will be left allocated on the context allocator.
 
+## Custom handlers
+
+By default this Toml modules makes several choices like, enums as string, members serialized by their name, no members omitted, etc.
+These choices may be fine for the large majority of use-case but not all. Custom handlers enable the user to modify the serialization/deserialization of types.
+
+Note that these custom handler drive "what" is (de)serialized, they do not help with formatting of the toml.
+
+Serialization can be modified by enabling `CUSTOM_HANDLERS` on the module and setting a custom handler procedure in the context.
+```jai
+enum_to_value :: (slot: *void, info: *Type_Info) -> done:=true, ok:=false, toml:Value=.{} {
+    if info.type != .ENUM return false;
+    enum_value := Reflection.get_enum_value(slot, xx info);
+    ok, value  := Toml.type_to_value(*enum_value, type_info(s64));
+    return true, ok, value;
+}
+
+ok, toml := Toml.serialize(
+    my_struct
+    ,, toml_custom_type_to_value = enum_to_value
+);
+
+#import "Toml"(CUSTOM_HANDLERS=true);
+```
+
 ## Testing
 `jai ./tests.jai`  
 - The module is tested by compiling and running the examples. The command above does that for all examples.
@@ -53,8 +77,14 @@ The module supports both Typed as well as Generic data using Toml.Value. To avoi
 ### Type reflection
 We only have a run-time reflection based implementation, e.g. pointer and Type_Info based like: `parse :: (slot: *void, info: Type_Info)`. A compile-time reflection based implementation that has the types determined at compile-time like `parse :: (data: *$T)` would have slightly cleaner code and better run-time performance, but it does not support dynamic types like Any. Having multiple implementations, or alternative solutions like requiring the user to poke_name a custom serializer for every possible type contained in the Any are considered undesirable.
 
-### [planned] Customization points
-A user may want to modify how a struct is serialized for example: omit members, rename members or create a specific toml structure. For various use cases we may implement specific solutions like notes on members that are required/optional, or their serialization name. For more complex cases we may allow the user to provide a procedure that converts A->B such that whenever an A occurs it is serialized as a B (note that B could be Toml.Value). Likely such a conversion procedures would come in pairs for serialization A->B and deserialization B->A.
+### Customization points
+Custom handlers have several design goals:
+ - Keep the core Toml module implementation clean from complexity.
+ - Enable custom serialization of types we do not own (external Modules) as we may not be able to add notes or remove members.
+ - The same type should be serializable in different ways defined at the procedure call site, not struct definition.
+ - Enable data tweaks during serialization as opposed to full copies of nested structure trees (separate structs for serialization and use within the application).
+
+In addition to handlers we currently also support making struct members optional through a @TomlOptional note. This means there are 2 ways to do the same thing and it also requires the data structure to be modified. It is likely this note will be removed when these kinds of operations are better supported through custom handlers.
 
 ### Lexer
 The tokenization/lexer phase completes before the parser starts. As a result memory needs to be allocated to store the tokens. There is no particular reason for this implementation other than that I wanted to experiment with this type of lexer. Unlike traditional lexers the one implemented here does not parse the tokens into literals like int/float/etc it just determines a token starts and ends. It is the responsibility of the parser to interpret the string when it has more context.

--- a/examples/custom_handlers.jai
+++ b/examples/custom_handlers.jai
@@ -1,0 +1,82 @@
+main :: () {
+    new_context := context;
+    new_context.toml_custom_type_to_value = custom_type_to_value;
+
+    push_context new_context {
+        magic := Magic_Bytes.{.[0x00, 0x43, 0xf2]}; // Assumes little_endian
+        ok, toml  := Toml.serialize(magic); assert(ok);
+        assert(toml == "flag=\"A\"\nsigned=-3517\n", "%", toml);
+
+        magic.bytes[0] = 0x01;
+        ok, toml = Toml.serialize(magic); assert(ok);
+        assert(toml == "unaltered=[1, 67, 242]\n", "%", toml);
+
+        magic.bytes[0] = 0x02;
+        ok = Toml.serialize(magic); assert(!ok);
+    }
+
+    new_context.toml_custom_value_to_type = custom_value_to_type;
+
+    push_context new_context {
+        ok, magic := Toml.deserialize("flag=\"A\"\nsigned=-3517\n", Magic_Bytes); assert(ok);
+        assert(magic.bytes[0] == 0x00 && magic.bytes[1] == 0x43 && magic.bytes[2] == 0xf2, "%", magic);
+
+        ok, magic = Toml.deserialize("unaltered=[1, 67, 242]\n", Magic_Bytes); assert(ok);
+        assert(magic.bytes[0] == 0x01 && magic.bytes[1] == 0x43 && magic.bytes[2] == 0xf2, "%", magic);
+
+        ok = Toml.deserialize("unaltered=[2, 67, 242, 0]\n", Magic_Bytes); assert(!ok);
+    }
+}
+
+Magic_Bytes :: struct {
+    bytes : [3]u8;
+};
+custom_type_to_value :: (slot: *void, info: *Type_Info) -> done:=true, ok:=false, toml:Value=.{} {
+    if info != type_info(Magic_Bytes) return false;
+
+    ret: Toml.Value; // Defaults inits to Table
+    if slot.(*u8).* == {
+    case 0;
+        ok, flag    := Toml.type_to_value(*"A", type_info(string)); if !ok return;
+        ok=, signed := Toml.type_to_value(slot+1, type_info(s16)); if !ok return;
+        array_add(*ret.table, .{key="flag", value=flag}, .{key="signed", value=signed});
+    case 1;
+        ok, array := Toml.type_to_value(slot, type_info([3]u8)); if !ok return;
+        array_add(*ret.table, .{key="unaltered", value=array});
+    case;
+        log_error("Invalid Magic_Bytes: %", slot.(*Magic_Bytes).*);
+        return;
+    }
+    return true, true, ret;
+}
+custom_value_to_type :: (toml: Value, slot: *void, info: *Type_Info, parent_name:string, name:string) -> done:=true, ok:=false {
+    if info != type_info(Magic_Bytes) return false;
+
+    if toml.type != .TABLE { log_error("Expected table for Magic_Bytes, got %", toml.type); return; }
+    if toml.table.count == {
+    case 2;
+        if toml.table[0].key != "flag"   { log_error("Expected key 'flag' for Magic_Bytes, got %",   toml.table[0].key); return; }
+        if toml.table[1].key != "signed" { log_error("Expected key 'signed' for Magic_Bytes, got %", toml.table[1].key); return; }
+
+
+        Flag :: enum u8 { A :: 0; }
+        ok := Toml.value_to_type(toml.table[0].value, slot, type_info(Flag), name, "flag"); if !ok return;
+        ok = Toml.value_to_type(toml.table[1].value, slot+1, type_info(s16), name, "signed");
+        return true, ok;
+    case 1;
+        if toml.table[0].key != "unaltered" { log_error("Expected key 'unaltered' for Magic_Bytes, got %", toml.table[0].key); return; }
+        ok := Toml.value_to_type(toml.table[0].value, slot, type_info([3]u8), name, "unaltered"); if !ok return;
+        if slot.(*Magic_Bytes).bytes[0] != 0x01 {
+            log_error("Expected 0x01 for unaltered Magic_Bytes, got %", slot.(*Magic_Bytes).bytes[0]);
+            return;
+        }
+        log("Magic_Bytes unaltered: %", slot.(*Magic_Bytes).bytes);
+        return true, ok;
+    }
+    log_error("Expected 1 or 2 keys for Magic_Bytes, got %", toml.table.count);
+    return;
+}
+
+
+using Toml :: #import, file "../module.jai"(CUSTOM_HANDLERS=true);
+#import "Basic";

--- a/examples/custom_handlers.jai
+++ b/examples/custom_handlers.jai
@@ -1,6 +1,88 @@
-main :: () {
+
+
+enum_as_int :: () {
+    Paprika :: enum { GREEN; ORANGE; RED; }
+    Basket :: struct {
+        paprika: Paprika;
+        everything_else: u8;
+    }
+
+    custom_enum_to_value :: (slot: *void, info: *Type_Info) -> done:=true, ok:=false, toml:Value=.{} {
+        if info.type != .ENUM return false;
+        enum_value := Reflection.get_enum_value(slot, xx info);
+        ok, value  := Toml.type_to_value(*enum_value, type_info(s64));
+        return true, ok, value;
+    }
+
+    basket := Basket.{paprika=.ORANGE, everything_else=42};
+    ok1, toml1 := Toml.serialize(basket);                                                    assert(ok1);
+    ok2, toml2 := Toml.serialize(basket,, toml_custom_type_to_value = custom_enum_to_value); assert(ok2);
+    assert(toml1 == "paprika=\"ORANGE\"\neverything_else=42\n", "%", toml1);
+    assert(toml2 == "paprika=1\neverything_else=42\n", "%", toml2);
+
+    // Deserialize with custom value_to_type
+
+    custom_value_to_enum :: (toml: Value, slot: *void, info: *Type_Info, parent_name:string, name:string) -> done:=true, ok:=false {
+        if info.type != .ENUM return false;
+        expect(toml.type, .INT, parent_name, name);
+        enum_info :*Type_Info_Enum = xx info;
+
+        found := array_find(enum_info.values, toml.int_value);
+        if !found { log_error("Value % is not a variant of enum %", toml.int_value, enum_info.name); return; }
+        Reflection.set_enum_value(slot, enum_info, toml.int_value);
+        return true, true;
+    }
+
+    ok3, basket3 := Toml.deserialize("paprika=\"RED\"\neverything_else=3\n", Basket);                                              assert(ok3);
+    ok4, basket4 := Toml.deserialize("paprika=2\neverything_else=3\n", Basket,, toml_custom_value_to_type = custom_value_to_enum); assert(ok4);
+    assert(basket3.paprika == .RED && basket3.everything_else == 3, "%", basket3);
+    assert(basket4.paprika == .RED && basket4.everything_else == 3, "%", basket3);
+}
+
+member_modifications :: () {
+    ThreeNamed :: struct {
+        a: u8;
+        b: u8;
+        c: u8;
+    }
+
+    two_renamed_type_info :: () -> Type_Info_Struct {
+        renamed_info := type_info(ThreeNamed).*;
+        renamed_info.members = array_copy(renamed_info.members); // Note: temp not needed as all memory will be on a context allocator as is required by the Toml interface.
+        renamed_info.members[0].name = "alpha";
+        renamed_info.members[2].name = "gamma";
+        array_unordered_remove_by_index(*renamed_info.members, 1);
+        return renamed_info;
+    }
+    custom_modified_to_value :: (slot: *void, info: *Type_Info) -> done:=true, ok:=false, toml:Value=.{} {
+        if info != type_info(ThreeNamed) return false;
+        modified_info := two_renamed_type_info();
+        ok, value := Toml.type_to_value(slot, *modified_info);
+        return true, ok, value;
+    }
+    custom_value_to_modified :: (toml: Value, slot: *void, info: *Type_Info, parent_name:string, name:string) -> done:=true, ok:=false {
+        if info != type_info(ThreeNamed) return false;
+        modified_info := two_renamed_type_info();
+        ok := Toml.value_to_type(toml, slot, *modified_info, parent_name, name);
+        return true, ok;
+    }
+
+    three_named := ThreeNamed.{a=1, b=2, c=3};
+    ok1, toml1 := Toml.serialize(three_named);                                                        assert(ok1);
+    ok2, toml2 := Toml.serialize(three_named,, toml_custom_type_to_value = custom_modified_to_value); assert(ok2);
+    assert(toml1 == "a=1\nb=2\nc=3\n", "%", toml1);
+    assert(toml2 == "alpha=1\ngamma=3\n", "%", toml2);
+
+    ok3, three_named3 := Toml.deserialize("a=4\nb=5\nc=6\n", ThreeNamed);                                                           assert(ok3);
+    ok4, three_named4 := Toml.deserialize("alpha=4\ngamma=6\n", ThreeNamed,, toml_custom_value_to_type = custom_value_to_modified); assert(ok4);
+    assert(three_named3.a == 4 && three_named3.b == 5 && three_named3.c == 6, "%", three_named3);
+    assert(three_named4.a == 4 && three_named4.b == 0 && three_named4.c == 6, "%", three_named4);
+}
+
+arbitrary_magic :: () {
     new_context := context;
-    new_context.toml_custom_type_to_value = custom_type_to_value;
+    // Serialize with custom type_to_value
+    new_context.toml_custom_type_to_value = custom_magic_to_value;
 
     push_context new_context {
         magic := Magic_Bytes.{.[0x00, 0x43, 0xf2]}; // Assumes little_endian
@@ -15,7 +97,8 @@ main :: () {
         ok = Toml.serialize(magic); assert(!ok);
     }
 
-    new_context.toml_custom_value_to_type = custom_value_to_type;
+    // Deserialize with custom value_to_type
+    new_context.toml_custom_value_to_type = custom_value_to_magic;
 
     push_context new_context {
         ok, magic := Toml.deserialize("flag=\"A\"\nsigned=-3517\n", Magic_Bytes); assert(ok);
@@ -31,7 +114,7 @@ main :: () {
 Magic_Bytes :: struct {
     bytes : [3]u8;
 };
-custom_type_to_value :: (slot: *void, info: *Type_Info) -> done:=true, ok:=false, toml:Value=.{} {
+custom_magic_to_value :: (slot: *void, info: *Type_Info) -> done:=true, ok:=false, toml:Value=.{} {
     if info != type_info(Magic_Bytes) return false;
 
     ret: Toml.Value; // Defaults inits to Table
@@ -49,7 +132,7 @@ custom_type_to_value :: (slot: *void, info: *Type_Info) -> done:=true, ok:=false
     }
     return true, true, ret;
 }
-custom_value_to_type :: (toml: Value, slot: *void, info: *Type_Info, parent_name:string, name:string) -> done:=true, ok:=false {
+custom_value_to_magic :: (toml: Value, slot: *void, info: *Type_Info, parent_name:string, name:string) -> done:=true, ok:=false {
     if info != type_info(Magic_Bytes) return false;
 
     if toml.type != .TABLE { log_error("Expected table for Magic_Bytes, got %", toml.type); return; }
@@ -77,6 +160,12 @@ custom_value_to_type :: (toml: Value, slot: *void, info: *Type_Info, parent_name
     return;
 }
 
+main :: () {
+    enum_as_int();
+    member_modifications();
+    arbitrary_magic();
+}
 
 using Toml :: #import, file "../module.jai"(CUSTOM_HANDLERS=true);
 #import "Basic";
+Reflection :: #import "Reflection";

--- a/examples/custom_handlers.jai
+++ b/examples/custom_handlers.jai
@@ -1,27 +1,50 @@
 
+// By default this Toml modules makes several choices like, enums as string, members serialized by their name, no members omitted, etc.
+// These choices may be fine for the large majority of use-case but not all. Custom handlers enable the user to modify the serialization/deserialization of types.
+// Custom handlers have several design goals:
+// - Keep the core Toml module implementation clean from complexity.
+// - Enable custom serialization of types we do not own (external Modules) as we may not be able to add notes or remove members.
+// - The same type should be serializable in different ways defined at the procedure call site, not struct definition.
+// - Enable data tweaks during serialization as opposed to full copies of nested structure trees (separate structs for serialization and use within the application).
+//
+// Note that these custom handler drive "what" is (de)serialized, they do not help with formatting of the toml.
+
+// By default custom handler support is not compiled. We need to import the module with CUSTOM_HANDLERS=true to enable it.
+//
+// #import "Toml"(CUSTOM_HANDLERS=true);
+//
+// This will add 2 procedure members to the context:
+// - toml_custom_type_to_value := (slot: *void, info: *Type_Info) -> done:bool, ok:bool, toml:Value;
+// - toml_custom_value_to_type := (toml: Value, slot: *void, info:*Type_Info, parent_name:string, name:string) -> done:bool, ok:bool;
 
 enum_as_int :: () {
+    // By default enums are serialized as strings. We can change this to serialize them as their integer value.
     Paprika :: enum { GREEN; ORANGE; RED; }
     Basket :: struct {
         paprika: Paprika;
         everything_else: u8;
     }
 
+    // The user writes a procedure to handle the serialization of the enum
+    // from the data stored in slot and returns a Toml Value.
     custom_enum_to_value :: (slot: *void, info: *Type_Info) -> done:=true, ok:=false, toml:Value=.{} {
-        if info.type != .ENUM return false;
+        if info.type != .ENUM return false; // Alternatively we could check specifically for `info != type_info(Paprika)`
         enum_value := Reflection.get_enum_value(slot, xx info);
         ok, value  := Toml.type_to_value(*enum_value, type_info(s64));
-        return true, ok, value;
+        return true, ok, value; // By returning done=true we signal that the returned value should be used and to skip default serialization.
     }
 
+    // The user can then choose to set the custom handler at the call site.
+    // If it is not set the default handler will be used serializing the enum as a string.
+    // By setting the custom handler in the context enums are serialized as integers.
     basket := Basket.{paprika=.ORANGE, everything_else=42};
-    ok1, toml1 := Toml.serialize(basket);                                                    assert(ok1);
-    ok2, toml2 := Toml.serialize(basket,, toml_custom_type_to_value = custom_enum_to_value); assert(ok2);
-    assert(toml1 == "paprika=\"ORANGE\"\neverything_else=42\n", "%", toml1);
-    assert(toml2 == "paprika=1\neverything_else=42\n", "%", toml2);
+    ok_default, toml_default := Toml.serialize(basket);                                                    assert(ok_default);
+    ok_custom,  toml_custom  := Toml.serialize(basket,, toml_custom_type_to_value = custom_enum_to_value); assert(ok_custom);
+    assert(toml_default == "paprika=\"ORANGE\"\neverything_else=42\n", "%", toml_default);
+    assert(toml_custom  == "paprika=1\neverything_else=42\n",          "%", toml_custom );
 
-    // Deserialize with custom value_to_type
-
+    // For deserialization it works the same way, but in opposite direction.
+    // The custom procedure receives a Toml Value and writes into the slot.
     custom_value_to_enum :: (toml: Value, slot: *void, info: *Type_Info, parent_name:string, name:string) -> done:=true, ok:=false {
         if info.type != .ENUM return false;
         expect(toml.type, .INT, parent_name, name);
@@ -33,6 +56,7 @@ enum_as_int :: () {
         return true, true;
     }
 
+    // The user can again opt in to using the custom handler at the call site, by setting it in the context.
     ok3, basket3 := Toml.deserialize("paprika=\"RED\"\neverything_else=3\n", Basket);                                              assert(ok3);
     ok4, basket4 := Toml.deserialize("paprika=2\neverything_else=3\n", Basket,, toml_custom_value_to_type = custom_value_to_enum); assert(ok4);
     assert(basket3.paprika == .RED && basket3.everything_else == 3, "%", basket3);
@@ -40,6 +64,12 @@ enum_as_int :: () {
 }
 
 member_modifications :: () {
+    // The custom handlers for modifications to members like omitting, renaming, reordering work in a similar way.
+    // In general the trick is to create a new Type_Info with the desired modifications and then use the default serialization/deserialization.
+    // Note that often the simplest way to create a new Type_Info is by defining a new Type. When doing so
+    // be careful that the member offset_in_bytes is correct with respect to the original Type_Info.
+    // In this example we instead make a copy of the original Type_Info and modify it.
+    // We still need to be careful not to modify the original Type_info as the it needs to be a shallow copy (for custom handlers with pointers to sub-type_infos).
     ThreeNamed :: struct {
         a: u8;
         b: u8;
@@ -48,14 +78,14 @@ member_modifications :: () {
 
     two_renamed_type_info :: () -> Type_Info_Struct {
         renamed_info := type_info(ThreeNamed).*;
-        renamed_info.members = array_copy(renamed_info.members); // Note: temp not needed as all memory will be on a context allocator as is required by the Toml interface.
-        renamed_info.members[0].name = "alpha";
+        renamed_info.members = array_copy(renamed_info.members); // Note: temp not needed as all memory will be on a context allocator as is required by the Toml Module interface.
+        renamed_info.members[0].name = "alpha"; // Rename
         renamed_info.members[2].name = "gamma";
-        array_unordered_remove_by_index(*renamed_info.members, 1);
+        array_unordered_remove_by_index(*renamed_info.members, 1); // Omit
         return renamed_info;
     }
     custom_modified_to_value :: (slot: *void, info: *Type_Info) -> done:=true, ok:=false, toml:Value=.{} {
-        if info != type_info(ThreeNamed) return false;
+        if info != type_info(ThreeNamed) return false; // Use default serialization for everything else by returning done=false.
         modified_info := two_renamed_type_info();
         ok, value := Toml.type_to_value(slot, *modified_info);
         return true, ok, value;
@@ -67,24 +97,33 @@ member_modifications :: () {
         return true, ok;
     }
 
+    // When serializing with the custom handler, the members are renamed and the middle member is omitted.
     three_named := ThreeNamed.{a=1, b=2, c=3};
     ok1, toml1 := Toml.serialize(three_named);                                                        assert(ok1);
     ok2, toml2 := Toml.serialize(three_named,, toml_custom_type_to_value = custom_modified_to_value); assert(ok2);
     assert(toml1 == "a=1\nb=2\nc=3\n", "%", toml1);
     assert(toml2 == "alpha=1\ngamma=3\n", "%", toml2);
 
+    // Similarly, when deserializing with the custom handler, the members are renamed and the middle member is omitted.
+    // Note that we do not fail on the missing member as it is default initialized (in this case to 0).
     ok3, three_named3 := Toml.deserialize("a=4\nb=5\nc=6\n", ThreeNamed);                                                           assert(ok3);
     ok4, three_named4 := Toml.deserialize("alpha=4\ngamma=6\n", ThreeNamed,, toml_custom_value_to_type = custom_value_to_modified); assert(ok4);
     assert(three_named3.a == 4 && three_named3.b == 5 && three_named3.c == 6, "%", three_named3);
     assert(three_named4.a == 4 && three_named4.b == 0 && three_named4.c == 6, "%", three_named4);
 }
 
-arbitrary_magic :: () {
-    new_context := context;
-    // Serialize with custom type_to_value
+arbitrary_magic_binary_encoding :: () {
+    // The custom handlers enable us to do conversions of arbitrary complexity during serialization/deserialization.
+    // In this example we show how data in a binary encoding can be serialized to Toml and back.
+    // Remember that this binary blob could be at any part of a struct hierarchy,
+    // still we do not need to decode the blob before serialization. As we convert it when we encounter it.
+
+    // Serialize a binary encoding with custom type_to_value
+    new_context := context; // A different way to set the context custom handlers for multiple calls
     new_context.toml_custom_type_to_value = custom_magic_to_value;
 
     push_context new_context {
+        // Depending on the first byte we serialize the data differently.
         magic := Magic_Bytes.{.[0x00, 0x43, 0xf2]}; // Assumes little_endian
         ok, toml  := Toml.serialize(magic); assert(ok);
         assert(toml == "flag=\"A\"\nsigned=-3517\n", "%", toml);
@@ -93,20 +132,23 @@ arbitrary_magic :: () {
         ok, toml = Toml.serialize(magic); assert(ok);
         assert(toml == "unaltered=[1, 67, 242]\n", "%", toml);
 
+        // In a custom handler we can also check for invalid data and return done=true, ok=false which will propagate up.
         magic.bytes[0] = 0x02;
         ok = Toml.serialize(magic); assert(!ok);
     }
 
-    // Deserialize with custom value_to_type
+    // Deserialize to the binary encoding with custom value_to_type
     new_context.toml_custom_value_to_type = custom_value_to_magic;
 
     push_context new_context {
+        // When deserializing the data is converted back to the binary encoding from different looking Toml data.
         ok, magic := Toml.deserialize("flag=\"A\"\nsigned=-3517\n", Magic_Bytes); assert(ok);
         assert(magic.bytes[0] == 0x00 && magic.bytes[1] == 0x43 && magic.bytes[2] == 0xf2, "%", magic);
 
         ok, magic = Toml.deserialize("unaltered=[1, 67, 242]\n", Magic_Bytes); assert(ok);
         assert(magic.bytes[0] == 0x01 && magic.bytes[1] == 0x43 && magic.bytes[2] == 0xf2, "%", magic);
 
+        // Error propagation works the same way as with custom type_to_value.
         ok = Toml.deserialize("unaltered=[2, 67, 242, 0]\n", Magic_Bytes); assert(!ok);
     }
 }
@@ -163,7 +205,7 @@ custom_value_to_magic :: (toml: Value, slot: *void, info: *Type_Info, parent_nam
 main :: () {
     enum_as_int();
     member_modifications();
-    arbitrary_magic();
+    arbitrary_magic_binary_encoding();
 }
 
 using Toml :: #import, file "../module.jai"(CUSTOM_HANDLERS=true);

--- a/examples/first.jai
+++ b/examples/first.jai
@@ -48,9 +48,8 @@ DONE
     ok=, as_value := Toml.serialize(my_struct); assert(ok);
     print("%\n", as_value);
 
-    // If the TOML data does not contain a field that is present in the struct, the field will be initialized to its default value.
-    ok=, default_struct := Toml.deserialize("", Q); assert(ok);
-    assert(default_struct.q == 0, "%", default_struct.q);
+    // By default all members are required to be present in the TOML. @TomlOptional or a custom handler can be used to make them optional or ignored.
+    optionals();
 
     // When struct or pointer members of a struct are declared with `using` the member name are required in the TOML data.
     // If the member is anonymous the member name is an empty string "".
@@ -97,6 +96,23 @@ DONE
     error_handling();
 }
 
+optionals :: () {
+    // If the TOML data does not contain a field that is present in the struct deserialize will fail.
+    Required :: struct { blob : u8; }
+    ok := Toml.deserialize("", Required); assert(!ok);
+
+    // To always keep a member at the default value thus prevent attempting to read a field at all, even if it is present we can remove it from the Type_Info, see custom_handlers.jai,
+
+    // If however we to allow a field to be missing, but read it if it is present the member can be annotated with @TomlOptional
+    // The default value will be used if the field is missing.
+    Optionals :: struct {
+        a: u8 = 17; @TomlOptional
+        b: u8 = 18; @TomlOptional
+    }
+    ok=, optionals := Toml.deserialize("a=99", Optionals); assert(ok);
+    assert(optionals.a == 99 && optionals.b == 18, "%", optionals);
+}
+
 using_members :: () {
     // When a named member is declared `using` the member name is still required.
     Named_Using :: struct {
@@ -106,8 +122,7 @@ using_members :: () {
     assert(named_using1.hi.q == 98, "%", named_using1.hi.q);
     // When a struct members is declared with `using` the member name cannot be omitted in the TOML to set the data
     // This is to prevent having multiple ways to define the same data. It also reduced the amount of recursion we have to do when deserializing.
-    ok=, named_using2 := Toml.deserialize("q = 99", Named_Using); assert(ok);
-    assert(named_using2.q == 0, "%", named_using2.q); // 0 since is the default value when it is not set
+    ok = Toml.deserialize("q = 99", Named_Using); assert(!ok);
     // When serializing a using member it will also write the member name.
     ok=, named_using_str := Toml.serialize(named_using1); assert(ok);
     assert(named_using_str == "hi.q=98\n", "%", named_using_str);
@@ -221,13 +236,12 @@ DONE, StructMember); assert(ok);
     // Note that this may be unsafe if #place is used for a union use-case like a string overlapping some floats. In this case,
     // if the floats are "active" the string is still serialized assuming the data pointer is valid. -- Perhaps we should simply not allow #place.
     // When deserializing the last overlapping member in the struct definition that is also in the toml wins.
+    // It is recommended to make #place members @TomlOptional such that they are not all required.
     #import "Math";
     has_hash_place:= Plane3.{3., 81., .18, .65};
     print("has_hash_place: %\n", has_hash_place);
     ok=, hash_toml:= Toml.serialize(has_hash_place); assert(ok);
     print("hash_toml: %\n", hash_toml);
-    ok=, new_plane:= Toml.deserialize("[vector4] \n xy = {x=2., y=21.6} \n zw = {x=.12, y=.25}", Plane3); assert(ok);
-    assert("{2, 21.6, 0.12, 0.25}" == tprint("%", new_plane));
 }
 
 error_handling :: () {
@@ -274,8 +288,8 @@ reference_types :: () {
 
     // Pointer to fixed array with initializer
     Vingt :: struct       {
-        number : s8=20;
-        getal: Getal= 23;
+        number : s8=20; @TomlOptional
+        getal: Getal= 23; @TomlOptional
     }
     Fixed_Array :: struct {
         p_quatre: *[4]Vingt;
@@ -287,7 +301,7 @@ reference_types :: () {
 
     // Pointer to variant
     DefaultStruct :: struct {
-        a: string="Anton";
+        a: string="Anton"; @TomlOptional
         b: s8;
     }
     DefaultVariant :: #type,distinct DefaultStruct;
@@ -305,12 +319,12 @@ reference_types :: () {
     MyPtrUsing :: struct {
         p_using: *MyUsing;
     }
-    ok=, use20 := Toml.deserialize("[p_using]\nnumber = 6", MyPtrUsing); assert(ok);
+    ok=, use20 := Toml.deserialize("[p_using]\na.number = 6", MyPtrUsing); assert(ok);
     print("use20: %\n", use20.p_using.*);
     assert(use20.p_using.getal == 23);
 
     // Union with first having an initializer
-    MyUnionStruct :: struct {
+    MyUnionStruct :: struct @SumType {
         tag : enum {
             FIRST;
             SECOND;
@@ -329,7 +343,7 @@ reference_types :: () {
     MyUnionPtr :: struct {
         p_union: *MyUnionStruct;
     }
-    ok=, un_ptr := Toml.deserialize("tag = 'FIRST' \n p_union.''.first.number = 3", MyUnionPtr); assert(ok);
+    ok=, un_ptr := Toml.deserialize("p_union.FIRST.number = 3", MyUnionPtr); assert(ok);
     print("un_ptr: %: %\n", un_ptr.p_union.tag, un_ptr.p_union.first);
     assert(un_ptr.p_union.first.number == 3);
     assert(un_ptr.p_union.first.getal == 23);

--- a/examples/first.jai
+++ b/examples/first.jai
@@ -9,7 +9,6 @@ main :: () {
     print("%\n", toml);
 
     // We can also deserialize the TOML data into a struct. The struct must have the same fields as the TOML data.
-    // The struct can have additional fields that are not present in the TOML data, in this case the fields will be initialized to their default values.
     // The TOML can have additional fields that are not present in the struct, in this case the fields will be ignored.
 THE_STRING :: #string DONE
 orange = false
@@ -101,12 +100,13 @@ optionals :: () {
     Required :: struct { blob : u8; }
     ok := Toml.deserialize("", Required); assert(!ok);
 
-    // To always keep a member at the default value thus prevent attempting to read a field at all, even if it is present we can remove it from the Type_Info, see custom_handlers.jai,
+    // To always keep a member at the default value thus prevent attempting to read a field at all,
+    // even if it is present we can remove it from the Type_Info, see custom_handlers.jai,
 
     // If however we to allow a field to be missing, but read it if it is present the member can be annotated with @TomlOptional
     // The default value will be used if the field is missing.
     Optionals :: struct {
-        a: u8 = 17; @TomlOptional
+        a: u8 = 17; @TomlOptional // @TomlOptional may be removed in the future in favor of a convenience procedure to use in a custom handler.
         b: u8 = 18; @TomlOptional
     }
     ok=, optionals := Toml.deserialize("a=99", Optionals); assert(ok);

--- a/module.jai
+++ b/module.jai
@@ -1,3 +1,5 @@
+#module_parameters(CUSTOM_HANDLERS := false);
+
 #load "src/data.jai";
 #load "src/serialize.jai";
 #load "src/deserialize.jai";

--- a/src/deserialize.jai
+++ b/src/deserialize.jai
@@ -11,15 +11,23 @@ value_to_type :: (value: Value, $Target: Type) -> ok:=false, value:Target=.{} {
     return ok, target;
 }
 
-#scope_module
+#if CUSTOM_HANDLERS {
+    #add_context toml_custom_value_to_type: (toml: Value, slot: *void, info:*Type_Info, parent_name:string, name:string) -> done:bool, ok:bool;
+}
 
+// Note meant to be called by the user directly, but instead to be used inside custom deserializers
 // slot is already initialized memory
 // Currently all fields are optional. TODO check TomlOptional Note and require_all true/false
 value_to_type :: (toml: Value, slot: *void, info: *Type_Info, parent_name:string="", name:string="") -> ok:=false {
+    #if CUSTOM_HANDLERS {
+        done, ok := context.toml_custom_value_to_type(toml, slot, info, parent_name, name);
+        if done return ok;
+    }
+
     if #complete info.type == {
     case .INTEGER;
         expect(toml.type, .INT, parent_name, name);
-        valid, low, high := range_check_and_store(toml.int_value, cast(*Type_Info_Integer, info), slot);
+        valid, low, high := range_check_and_store(toml.int_value, xx info, slot);
         if !valid { return_with_error("Value for %.% is out of range. Given % expected min % max %", parent_name, name, toml.int_value, low, high); }
     case .FLOAT;
         if toml.type != .INT expect(toml.type, .FLOAT, parent_name, name); // Allow int to float conversion
@@ -60,28 +68,29 @@ value_to_type :: (toml: Value, slot: *void, info: *Type_Info, parent_name:string
         array_info :*Type_Info_Array= xx info;
         element_type := array_info.element_type;
 
-        fill_array :: (toml_array: []Value, slot: *void, item_info: *Type_Info, parent_name:string) {
+        fill_array :: (toml_array: []Value, slot: *void, item_info: *Type_Info, parent_name:string) -> ok:=false {
             for idx: 0..toml_array.count-1 {
                 item_slot := slot + item_info.runtime_size * idx;
                 ok := value_to_type(toml_array[idx], item_slot, item_info, parent_name, "[item]"); if !ok return;
             }
+            return true;
         }
         if #complete array_info.array_type == {
         case .FIXED;
             if toml.array.count != array_info.array_count { return_with_error("Fixed array %.% expected % items, got %", parent_name, name, array_info.array_count, toml.array.count); }
-            fill_array(toml.array, slot, element_type, name); // NOTE .FIXED is inside the struct so already initialized
+            ok := fill_array(toml.array, slot, element_type, name); if !ok return; // NOTE .FIXED is inside the struct so already initialized
         case .VIEW;
             array := cast(*[] u8, slot);
             array.data = alloc(toml.array.count * element_type.runtime_size);
             array.count = toml.array.count;
             initialize_memory(array.data, element_type, array.count);
-            fill_array(toml.array, array.data, element_type, name);
+            ok := fill_array(toml.array, array.data, element_type, name); if !ok return;
         case .RESIZABLE;
             array := cast(*[..] u8, slot);
             array_reserve(array, toml.array.count * element_type.runtime_size);
             array.count = toml.array.count;
             initialize_memory(array.data, element_type, array.count);
-            fill_array(toml.array, array.data, element_type, name);
+            ok := fill_array(toml.array, array.data, element_type, name); if !ok return;
         }
     case .ANY;
         any_value :*Any_Struct= xx slot;
@@ -103,7 +112,7 @@ value_to_type :: (toml: Value, slot: *void, info: *Type_Info, parent_name:string
 
         found, index := array_find(enum_info.names, toml.string_value);
         if !found { return_with_error("String % is not a variant of enum %", toml.string_value, enum_info.name); }
-        set_enum_value(slot, enum_info, enum_info.values[index]);
+        Reflection.set_enum_value(slot, enum_info, enum_info.values[index]);
     case .VARIANT;
         variant_info :*Type_Info_Variant= xx info;
         return value_to_type(toml, slot, variant_info.variant_of, parent_name, name);
@@ -135,7 +144,7 @@ value_to_sumtype :: (toml_table: []KeyValue, slot: *void, struct_info: *Type_Inf
     if toml_table.count != 1  return_with_error("SumType % should have exactly one key-value pair", struct_info.name);
 
     for tag_info.names if it == toml_table[0].key {
-        set_enum_value(slot + tag_member.offset_in_bytes, tag_info, tag_info.values[it_index]);
+        Reflection.set_enum_value(slot + tag_member.offset_in_bytes, tag_info, tag_info.values[it_index]);
         active_variant:= union_info.members[it_index];
         return value_to_type(toml_table[0].value, slot + union_member.offset_in_bytes + active_variant.offset_in_bytes, active_variant.type, parent_name, toml_table[0].key);
     }
@@ -156,6 +165,8 @@ is_valid_sumtype :: (struct_info: *Type_Info_Struct) -> bool, tag_member:*Type_I
 expect :: inline (given: Value.Type, expected: Value.Type, struct_name: string, member_name: string) #expand {
     if given != expected { `return_with_error("Wrong type for %.%, expected %, got % ", struct_name, member_name, expected, given); }
 }
+
+#scope_module
 
 //
 // Generic memory utilities
@@ -204,6 +215,31 @@ get_integer_value :: (data: *void, info: *Type_Info_Integer) -> ok:=false, value
     }
 }
 
+range_check_and_store :: (value: s64, info: *Type_Info_Integer, pointer: *void) -> ok:bool, low:s64, high:s64 {
+    low, high :s64= ---;
+    if info.signed || info.runtime_size == 8 {
+        low, high =    Reflection.signed_integer_range_from_size(info.runtime_size);
+    } else {
+        ulow, uhigh := Reflection.unsigned_integer_range_from_size(info.runtime_size);
+        low, high = ulow.(s64), uhigh.(s64);
+    }
+    if (value < low) || (value > high)  return false, low, high;
+
+    if info.signed if info.runtime_size == {
+        case 1; pointer.(*s8) .* = xx,no_check value;
+        case 2; pointer.(*s16).* = xx,no_check value;
+        case 4; pointer.(*s32).* = xx,no_check value;
+        case 8; pointer.(*s64).* = xx,no_check value;
+    }
+    else if info.runtime_size == {
+        case 1; pointer.(*u8) .* = xx,no_check value;
+        case 2; pointer.(*u16).* = xx,no_check value;
+        case 4; pointer.(*u32).* = xx,no_check value;
+        case 8; pointer.(*u64).* = xx,no_check value;
+    }
+    return true, low, high;
+}
+
 scoped_pool :: () -> Allocator #expand {
     pool: Flat_Pool;
     a: Allocator;
@@ -215,5 +251,5 @@ scoped_pool :: () -> Allocator #expand {
 
 #scope_file
 #load "parser.jai";
-#import "Reflection";
+Reflection :: #import "Reflection";
 #import "Flat_Pool";

--- a/src/deserialize.jai
+++ b/src/deserialize.jai
@@ -58,10 +58,13 @@ value_to_type :: (toml: Value, slot: *void, info: *Type_Info, parent_name:string
         if array_find(struct_info.notes, "SumType") { return value_to_sumtype(toml.table, slot, struct_info, parent_name); }
         for member: struct_info.members {
             if member.flags & (.CONSTANT |.IMPORTED) continue;
+            found := false;
             for toml.table if it.key == member.name {
+                found = true;
                 ok:= value_to_type(it.value, slot + member.offset_in_bytes, member.type, parent_name, member.name);  if !ok return;
                 break;
             }
+            if !found && !array_find(member.notes, "TomlOptional") return_with_error("Missing field %.%", struct_info.name, member.name);
         }
     case .ARRAY;
         expect(toml.type, .ARRAY, parent_name, name);

--- a/src/deserialize.jai
+++ b/src/deserialize.jai
@@ -12,7 +12,7 @@ value_to_type :: (value: Value, $Target: Type) -> ok:=false, value:Target=.{} {
 }
 
 #if CUSTOM_HANDLERS {
-    #add_context toml_custom_value_to_type: (toml: Value, slot: *void, info:*Type_Info, parent_name:string, name:string) -> done:bool, ok:bool;
+    #add_context toml_custom_value_to_type:= (toml: Value, slot: *void, info:*Type_Info, parent_name:string, name:string) -> done:bool, ok:bool { return false, true; };
 }
 
 // Note meant to be called by the user directly, but instead to be used inside custom deserializers

--- a/src/deserialize.jai
+++ b/src/deserialize.jai
@@ -205,7 +205,7 @@ get_integer_value :: (data: *void, info: *Type_Info_Integer) -> ok:=false, value
 }
 
 scoped_pool :: () -> Allocator #expand {
-    pool: Flat_Pool; // TBD does this needs to be backticked?
+    pool: Flat_Pool;
     a: Allocator;
     a.proc = flat_pool_allocator_proc;
     a.data = *pool;

--- a/src/lexer.jai
+++ b/src/lexer.jai
@@ -183,6 +183,8 @@ get_line :: (data: string, line_number: s32) -> line: string, found:bool {
     return line, found;
 }
 
+#scope_export
+
 return_with_error :: (format: string, arguments: .. Any) #expand {
     log_error(format, ..arguments);
     `return;

--- a/src/parser.jai
+++ b/src/parser.jai
@@ -1,6 +1,6 @@
 // Does not support:
 // - Rejecting all control characters
-// - Rejecting values that overwrite / append to previous ones!
+// - Rejecting values that append to previous inline ones
 // - Full toml validation like newlines in an inline table or numbers with leading zeros or _s
 
 #scope_module

--- a/src/serialize.jai
+++ b/src/serialize.jai
@@ -12,7 +12,7 @@ type_to_value :: (input: $T) -> ok:=false, value:Value=.{} {
 }
 
 #if CUSTOM_HANDLERS {
-    #add_context toml_custom_type_to_value: (slot: *void, info: *Type_Info) -> done:bool, ok:bool, toml:Value;
+    #add_context toml_custom_type_to_value:= (slot: *void, info: *Type_Info) -> done:bool, ok:bool, toml:Value { return false, true, .{}; };
 }
 
 // NOTE: Does not deep copy!

--- a/src/serialize.jai
+++ b/src/serialize.jai
@@ -11,10 +11,18 @@ type_to_value :: (input: $T) -> ok:=false, value:Value=.{} {
     return ok, copy(value);
 }
 
-#scope_module
+#if CUSTOM_HANDLERS {
+    #add_context toml_custom_type_to_value: (slot: *void, info: *Type_Info) -> done:bool, ok:bool, toml:Value;
+}
 
-// Note: Does not deep copy
+// NOTE: Does not deep copy!
+// Not meant to be called directly by the user, but instead to be used inside custom serializers.
 type_to_value :: (slot: *void, info: *Type_Info) -> ok:=false, toml:Value=.{} {
+    #if CUSTOM_HANDLERS {
+        done, ok, value := context.toml_custom_type_to_value(slot, info);
+        if done return ok, value;
+    }
+
     if #complete info.type == {
     case .INTEGER;
         ok, value := get_integer_value(slot, xx info); if !ok return;
@@ -75,7 +83,7 @@ type_to_value :: (slot: *void, info: *Type_Info) -> ok:=false, toml:Value=.{} {
         return ok, value;
     case .ENUM;
         enum_info :*Type_Info_Enum= xx info;
-        enum_value:= get_enum_value(slot, enum_info);
+        enum_value:= Reflection.get_enum_value(slot, enum_info);
         for enum_info.values  if it == enum_value {
             return true, .{type=.STRING, string_value=enum_info.names[it_index]};
         }
@@ -94,7 +102,7 @@ sumtype_to_value :: (slot: *void, struct_info: *Type_Info_Struct) -> ok:=false, 
     valid, tag_member, union_member, tag_info, union_info:= is_valid_sumtype(struct_info);
     if !valid { return_with_error("SumType % is not valid", struct_info.name); }
 
-    active_tag_idx:= get_enum_value(slot + tag_member.offset_in_bytes, xx tag_member.type);
+    active_tag_idx:= Reflection.get_enum_value(slot + tag_member.offset_in_bytes, xx tag_member.type);
     active_variant:= union_info.members[active_tag_idx];
     variant_slot:= slot + union_member.offset_in_bytes + active_variant.offset_in_bytes;
     if is_null(variant_slot, active_variant.type) return_with_error("Null pointer in SumType detected which is not supported");
@@ -110,6 +118,8 @@ is_null :: (slot: *void, info: *Type_Info) -> bool {
     if info.type == .ANY     return cast(*Any_Struct, slot).value_pointer == null;
     return false;
 }
+
+#scope_module
 
 print_table_to_builder :: (builder: *String_Builder, value: Value, parent_key: string = "") {
     assert(value.type == .TABLE, "Only tables can be serialized at the top level, got %", value.type);
@@ -243,3 +253,4 @@ build_dotted_key :: (parent_key: string, key: string) -> string {
 #scope_file
 #import "Basic";
 #import "Math";
+Reflection :: #import "Reflection";

--- a/tests.jai
+++ b/tests.jai
@@ -9,6 +9,7 @@
     test("./examples", "first", args);
     test("./examples", "file_examples", args);
     test("./examples", "validation", args);
+    test("./examples", "custom_handlers", args);
     print("Tests ran in % seconds\n", seconds_since_init() - t0);
 
     set_build_options_dc(.{do_output=false});


### PR DESCRIPTION
- Support for custom handlers, enabled by a module flag
- Fixed array deserialization not propagating an error
- Fix unsigned int deserializing was using signed range check
- Expose more internal procedures to support the creation of custom handlers
- Added Jai version shield to readme
- Make all members required
- Add @TomlOptional as a note to make it not required, maybe removed in the future