### PR TITLE
Toml test v2.1.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2025 Sjors Donkers
+Copyright (c) 2024-2026 Sjors Donkers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/datetime.jai
+++ b/src/datetime.jai
@@ -86,7 +86,10 @@ parse_time :: (input: string) -> ok:=false, value:Time=.{} {
     if input.count > 8 {
         if input[8] != "." return;
         ms_digit_count := min(3, input.count - 9);
-        millisecond  = slice_to_int(input, 9, ms_digit_count, u16);
+        millisecond = slice_to_int(input, 9, ms_digit_count, u16);
+        // Scale fractional seconds to milliseconds: .6 (1 digit) = 600ms, .60 (2 digits) = 600ms
+        if ms_digit_count == 1      millisecond *= 100;
+        else if ms_digit_count == 2 millisecond *= 10;
         if ms_digit_count > 3 { // We only store the minimum required precision to support (milliseconds)
             ignored     := slice_to_int(input, 9 + ms_digit_count, input.count - 9 - ms_digit_count, u64);
         }
@@ -117,15 +120,29 @@ parse_date :: (input: string) -> ok:=false, value:Date=.{} {
     return true, Date.{year=year, month=month, day=day};
 }
 
-// Formats a time to a string in the format "HH:MM:SS.SSS"
+// Formats a time to a string in the format "HH:MM:SS[.SSS]"
 print_time_to_builder :: (builder: *String_Builder, time: Time) {
     print_integer(builder, formatInt(time.hour, minimum_digits=2));
     append(builder, ":");
     print_integer(builder, formatInt(time.minute, minimum_digits=2));
     append(builder, ":");
     print_integer(builder, formatInt(time.second, minimum_digits=2));
-    append(builder, ".");
-    print_integer(builder, formatInt(time.millisecond, minimum_digits=3));
+
+    // Only append fractional seconds if non-zero
+    if time.millisecond > 0 {
+        append(builder, ".");
+        // Remove trailing zeros by finding the number of significant digits
+        if time.millisecond % 100 == 0 {
+            // Divisible by 100: output only 1 digit
+            print_integer(builder, formatInt(time.millisecond / 100, minimum_digits=1));
+        } else if time.millisecond % 10 == 0 {
+            // Divisible by 10: output only 2 digits
+            print_integer(builder, formatInt(time.millisecond / 10, minimum_digits=2));
+        } else {
+            // Output all 3 digits
+            print_integer(builder, formatInt(time.millisecond, minimum_digits=3));
+        }
+    }
 }
 // Formats a date to a string in the format "YYYY-MM-DD"
 print_date_to_builder :: (builder: *String_Builder, date: Date) {

--- a/src/datetime.jai
+++ b/src/datetime.jai
@@ -127,22 +127,8 @@ print_time_to_builder :: (builder: *String_Builder, time: Time) {
     print_integer(builder, formatInt(time.minute, minimum_digits=2));
     append(builder, ":");
     print_integer(builder, formatInt(time.second, minimum_digits=2));
-
-    // Only append fractional seconds if non-zero
-    if time.millisecond > 0 {
-        append(builder, ".");
-        // Remove trailing zeros by finding the number of significant digits
-        if time.millisecond % 100 == 0 {
-            // Divisible by 100: output only 1 digit
-            print_integer(builder, formatInt(time.millisecond / 100, minimum_digits=1));
-        } else if time.millisecond % 10 == 0 {
-            // Divisible by 10: output only 2 digits
-            print_integer(builder, formatInt(time.millisecond / 10, minimum_digits=2));
-        } else {
-            // Output all 3 digits
-            print_integer(builder, formatInt(time.millisecond, minimum_digits=3));
-        }
-    }
+    append(builder, ".");
+    print_integer(builder, formatInt(time.millisecond, minimum_digits=3));
 }
 // Formats a date to a string in the format "YYYY-MM-DD"
 print_date_to_builder :: (builder: *String_Builder, date: Date) {

--- a/src/datetime.jai
+++ b/src/datetime.jai
@@ -120,7 +120,7 @@ parse_date :: (input: string) -> ok:=false, value:Date=.{} {
     return true, Date.{year=year, month=month, day=day};
 }
 
-// Formats a time to a string in the format "HH:MM:SS[.SSS]"
+// Formats a time to a string in the format "HH:MM:SS.SSS"
 print_time_to_builder :: (builder: *String_Builder, time: Time) {
     print_integer(builder, formatInt(time.hour, minimum_digits=2));
     append(builder, ":");

--- a/src/parser.jai
+++ b/src/parser.jai
@@ -127,6 +127,7 @@ parse_literal :: (scope: *Scope) -> ok:=false, literal:Value=.{} {
             for us_split if it.count == 0 then return_with_error_line(scope.source, token.loc, "Invalid placement of _ in integer literal %", token.str);
 
             without_base := slice(clean_str, 2, clean_str.count - 2);
+            if without_base.count > 0 && (without_base[0] == "+" || without_base[0] == "-") then return_with_error_line(scope.source, token.loc, "Invalid hex/binary/octal literal %", token.str);
             base := ifx clean_str[1] == "x" then 16 else ifx clean_str[1] == "b" then 2 else 8;
             value, ok, remainder := string_to_int_checked(without_base, base, s64);
             if !ok || remainder.count != 0 then return_with_error_line(scope.source, token.loc, "Invalid hex/binary/octal literal %", token.str);

--- a/tools/toml-test/README.md
+++ b/tools/toml-test/README.md
@@ -5,25 +5,19 @@ A perf app is implemented to run the performance test from `toml-test`.
 
 ## Run
 
-> The `jai` and `toml-test` executables should be in the PATH.
+> The `jai` and `toml-test-v2.1.0` executables should be in the PATH.
 
-Test with the decoder:
+Test with the decoder and encoder:
 ```sh
 jai ./decoder.jai
-toml-test ./decoder -run 'valid/*'
-```
-
-Test with the encoder:
-```sh
-jai ./encoder.jai
-toml-test -encoder ./encoder
+toml-test-v2.1.0 test -decoder="./decoder" -encoder="./encoder" -toml="1.0"
 ```
 
 The `run_toml-tests` app is used for the test framework to compile and run both in sequence.
 
-Run perf:
+Run perf: (note: test files were generated with v1.6.0)
 ```sh
-toml-test -cat 10 > 10kb.toml
+toml-test-v1.6.0 -cat 10 > 10kb.toml
 jai ./perf.jai
 ./perf 10kb.toml
 ```

--- a/tools/toml-test/run_toml-tests.jai
+++ b/tools/toml-test/run_toml-tests.jai
@@ -23,7 +23,7 @@ main :: () {
     // Check if the toml-test can be found
     result := run_command(bin, "version", capture_and_return_output=true);
     if result.type != .EXITED || result.exit_code != 0 {
-        log_error("'%s' not found in PATH, see https://github.com/toml-lang/toml-test", bin);
+        log_error("'%s' not found in PATH, or not execute permission, see https://github.com/toml-lang/toml-test", bin);
         exit(2);
     }
 

--- a/tools/toml-test/run_toml-tests.jai
+++ b/tools/toml-test/run_toml-tests.jai
@@ -16,19 +16,18 @@
 // Runs the toml-test with the decoder and encoder (for the set of test that are successful)
 // the `toml-test` executable is expected to be in the current directory or in the PATH
 main :: () {
+    #if OS == {
+        case .WINDOWS; bin := "toml-test-v2.1.0.exe";
+        case;          bin := "toml-test-v2.1.0";
+    }
     // Check if the toml-test can be found
-    result := run_command("toml-test", "--version", capture_and_return_output=true);
+    result := run_command(bin, "version", capture_and_return_output=true);
     if result.type != .EXITED || result.exit_code != 0 {
-        log_error("'toml-test' not found in PATH, see https://github.com/toml-lang/toml-test");
+        log_error("'%s' not found in PATH, see https://github.com/toml-lang/toml-test", bin);
         exit(2);
     }
 
-    result=, stdout, stderr := run_command("toml-test", "./decoder", capture_and_return_output=true);
-    log("\n%", stdout);
-    if stderr log_error(stderr);
-    if result.type != .EXITED || result.exit_code != 0 exit(1);
-
-    result, stdout, stderr = run_command("toml-test", "-encoder", "./encoder", capture_and_return_output=true);
+    result=, stdout, stderr := run_command(bin, "test", "-decoder=./decoder", "-encoder=./encoder", "-toml=1.0", capture_and_return_output=true);
     log("\n%", stdout);
     if stderr log_error(stderr);
     if result.type != .EXITED || result.exit_code != 0 exit(1);


### PR DESCRIPTION
Fixes parsing milliseconds parsing .6 should be 600 not 6.
Rejects illegal sign prefixes for hex, oct, and dec numbers